### PR TITLE
Propagate labels

### DIFF
--- a/pkg/reconciler/v1alpha1/build/build.go
+++ b/pkg/reconciler/v1alpha1/build/build.go
@@ -131,6 +131,7 @@ func (c *Reconciler) createKNBuild(namespace string, build *v1alpha1.Build) (*kn
 			OwnerReferences: []metav1.OwnerReference{
 				*kmeta.NewControllerRef(build),
 			},
+			Labels: build.Labels,
 		},
 		Spec: knv1alpha1.BuildSpec{
 			ServiceAccountName: build.Spec.ServiceAccount,

--- a/pkg/reconciler/v1alpha1/build/build_test.go
+++ b/pkg/reconciler/v1alpha1/build/build_test.go
@@ -77,6 +77,9 @@ func testBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 	build := &v1alpha1.Build{
 		ObjectMeta: v1.ObjectMeta{
 			Name: buildName,
+			Labels: map[string]string{
+				"some/label": "to-pass-through",
+			},
 		},
 		Spec: v1alpha1.BuildSpec{
 			Image:          "someimage/name",
@@ -116,6 +119,9 @@ func testBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 					Namespace: namespace,
 					OwnerReferences: []v1.OwnerReference{
 						*kmeta.NewControllerRef(build),
+					},
+					Labels: map[string]string{
+						"some/label": "to-pass-through",
 					},
 				})
 				assert.Equal(t, knbuild.Spec.ServiceAccountName, "someserviceaccount")

--- a/pkg/reconciler/v1alpha1/image/image.go
+++ b/pkg/reconciler/v1alpha1/image/image.go
@@ -171,12 +171,13 @@ func (c *Reconciler) reconcileSourceResolver(image *v1alpha1.Image) (*v1alpha1.S
 		}
 	}
 
-	if equality.Semantic.DeepEqual(desiredSourceResolver.Spec, sourceResolver.Spec) {
+	if sourceResolversEqual(desiredSourceResolver, sourceResolver) {
 		return sourceResolver, nil
 	}
 
 	sourceResolver = sourceResolver.DeepCopy()
 	sourceResolver.Spec = desiredSourceResolver.Spec
+	sourceResolver.Labels = desiredSourceResolver.Labels
 	return c.Client.BuildV1alpha1().SourceResolvers(image.Namespace).Update(sourceResolver)
 }
 
@@ -206,7 +207,7 @@ func (c *Reconciler) reconcileBuildCache(image *v1alpha1.Image) (*corev1.Persist
 		}
 	}
 
-	if equality.Semantic.DeepEqual(desiredBuildCache.Spec.Resources, buildCache.Spec.Resources) {
+	if buildCacheEqual(desiredBuildCache, buildCache) {
 		return buildCache, nil
 	}
 
@@ -286,6 +287,16 @@ func (c *Reconciler) updateStatus(desired *v1alpha1.Image) error {
 
 	_, err = c.Client.BuildV1alpha1().Images(desired.Namespace).UpdateStatus(desired)
 	return err
+}
+
+func sourceResolversEqual(desiredSourceResolver *v1alpha1.SourceResolver, sourceResolver *v1alpha1.SourceResolver) bool {
+	return equality.Semantic.DeepEqual(desiredSourceResolver.Spec, sourceResolver.Spec) &&
+		equality.Semantic.DeepEqual(desiredSourceResolver.Labels, sourceResolver.Labels)
+}
+
+func buildCacheEqual(desiredBuildCache *corev1.PersistentVolumeClaim, buildCache *corev1.PersistentVolumeClaim) bool {
+	return equality.Semantic.DeepEqual(desiredBuildCache.Spec.Resources, buildCache.Spec.Resources) &&
+		equality.Semantic.DeepEqual(desiredBuildCache.Labels, buildCache.Labels)
 }
 
 func (c *Reconciler) CreateBuild(build *v1alpha1.Build) (*v1alpha1.Build, error) {


### PR DESCRIPTION
Propagate labels on images to all child resources

- Update SourceResolver/BuildCaches when labels change
- Resolves #8