### PR TITLE
Remove dependency on Knative Build

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -412,27 +412,6 @@
   version = "0.5"
 
 [[projects]]
-  digest = "1:3a5f74d96cee6e094702734970ec83ba30779cf0d90bcd5dbe5746b09bceb1c3"
-  name = "github.com/knative/build"
-  packages = [
-    "pkg/apis/build",
-    "pkg/apis/build/v1alpha1",
-    "pkg/client/clientset/versioned",
-    "pkg/client/clientset/versioned/fake",
-    "pkg/client/clientset/versioned/scheme",
-    "pkg/client/clientset/versioned/typed/build/v1alpha1",
-    "pkg/client/clientset/versioned/typed/build/v1alpha1/fake",
-    "pkg/client/informers/externalversions",
-    "pkg/client/informers/externalversions/build",
-    "pkg/client/informers/externalversions/build/v1alpha1",
-    "pkg/client/informers/externalversions/internalinterfaces",
-    "pkg/client/listers/build/v1alpha1",
-  ]
-  pruneopts = "NUT"
-  revision = "0ff6554186913895288555b640b6af03173a2495"
-  version = "v0.7.0"
-
-[[projects]]
   branch = "release-0.7"
   digest = "1:ef42452c3d83cbda11af548a8f37b826835c42d0517e020fa02646e4055c9f20"
   name = "github.com/knative/pkg"
@@ -1439,12 +1418,6 @@
     "github.com/google/go-containerregistry/pkg/authn",
     "github.com/google/go-containerregistry/pkg/name",
     "github.com/google/go-containerregistry/pkg/v1/remote",
-    "github.com/knative/build/pkg/apis/build/v1alpha1",
-    "github.com/knative/build/pkg/client/clientset/versioned",
-    "github.com/knative/build/pkg/client/clientset/versioned/fake",
-    "github.com/knative/build/pkg/client/informers/externalversions",
-    "github.com/knative/build/pkg/client/informers/externalversions/build/v1alpha1",
-    "github.com/knative/build/pkg/client/listers/build/v1alpha1",
     "github.com/knative/pkg/apis",
     "github.com/knative/pkg/apis/duck/v1alpha1",
     "github.com/knative/pkg/controller",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -19,10 +19,6 @@ required = [
   name = "gopkg.in/yaml.v2"
   version = "v2.2.1"
 
-[[constraint]]
-  name = "github.com/knative/build"
-  version = "v0.7.0"
-
 [[override]]
   name = "github.com/knative/pkg"
   branch = "release-0.7"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Experimental Build Service CRDs.
 ## Pre requirements
 
 - Kubernetes cluster
-- KNative 0.7 installed
 
 ## Install
 
@@ -31,7 +30,7 @@ metadata:
 spec:
   image: cloudfoundry/cnb:bionic
 ``` 
-2. Create a service account with access to push to the desired docker registry. The example below is for a registry on gcr. Check out [Knative's documentation](https://knative.dev/docs/build/auth/) for more info. 
+2. Create a service account with access to push to the desired docker registry. The example below is for a registry on gcr. 
 
 ```yaml
 apiVersion: v1
@@ -39,7 +38,7 @@ kind: Secret
 metadata:
   name: basic-user-pass
   annotations:
-    build.knative.dev/docker-0: gcr.io 
+    build.pivotal.io/docker: gcr.io 
 type: kubernetes.io/basic-auth
 stringData:
   username: <username>

--- a/config/clusterrole.yaml
+++ b/config/clusterrole.yaml
@@ -4,18 +4,6 @@ metadata:
   name: build-service-system-admin
 rules:
 - apiGroups:
-  - build.knative.dev
-  resources:
-  - builds
-  verbs:
-  - get
-  - list
-  - create
-  - update
-  - delete
-  - patch
-  - watch
-- apiGroups:
   - build.pivotal.io
   resources:
   - builds
@@ -45,6 +33,7 @@ rules:
   - ""
   resources:
   - persistentvolumeclaims
+  - pods
   verbs:
   - get
   - list

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -22,3 +22,9 @@ spec:
         env:
         - name: BUILD_INIT_IMAGE
           value: #@ data.values.build_init_image
+        - name: GIT_INIT_IMAGE
+          value: gcr.io/cf-build-service-dev-219913/git-init@sha256:a0b587d97503ccce2109dcaa1462ff62be040388baeb3425507b300b9ecb3b86
+        - name: CRED_INIT_IMAGE
+          value: gcr.io/pivotal-knative/github.com/knative/build/cmd/creds-init@sha256:2bc85afc0ee0aec012b3889cf5f2e9690bb504c9d19ce90add2f415b85990895
+        - name: NOP_IMAGE
+          value: gcr.io/pivotal-knative/github.com/knative/build/cmd/nop@sha256:dc7e5e790001c71c2cfb175854dd36e65e0b71c58294b331a519be95bdec4ef4

--- a/pkg/apis/build/v1alpha1/build_pod.go
+++ b/pkg/apis/build/v1alpha1/build_pod.go
@@ -1,0 +1,396 @@
+package v1alpha1
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/knative/pkg/kmeta"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	SecretTemplateName           = "secret-volume-%s"
+	SecretPathName               = "/var/build-secrets/%s"
+	DOCKERSecretAnnotationPrefix = "build.pivotal.io/docker"
+	GITSecretAnnotationPrefix    = "build.pivotal.io/git"
+)
+
+type BuildPodConfig struct {
+	GitInitImage   string
+	BuildInitImage string
+	CredsInitImage string
+	NopImage       string
+}
+
+func (b *Build) BuildPod(config BuildPodConfig, secrets []corev1.Secret) (*corev1.Pod, error) {
+	const cacheDirName = "empty-dir"
+	const layersDirName = "layers-dir"
+	const platformDir = "platform-dir"
+
+	const homeDir = "home-dir"
+	const workspaceDir = "workspace-dir"
+
+	var root int64 = 0
+
+	buf, err := json.Marshal(b.Spec.Env)
+	if err != nil {
+		return nil, err
+	}
+	envVars := string(buf)
+
+	homeDirVolume := corev1.VolumeMount{
+		Name:      homeDir,
+		MountPath: "/builder/home",
+	}
+	workspaceVolume := corev1.VolumeMount{
+		Name:      workspaceDir,
+		MountPath: "/workspace",
+	}
+	volumes := []corev1.Volume{
+		{
+			Name:         cacheDirName,
+			VolumeSource: b.cacheVolume(),
+		},
+		{
+			Name: layersDirName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
+			Name: homeDir,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
+			Name: workspaceDir,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+
+		{
+			Name: platformDir,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+	}
+	secretVolumes, secretVolumeMounts, secretArgs, err := b.secretVolumesArgs(secrets)
+	if err != nil {
+		return nil, err
+	}
+	volumes = append(volumes, secretVolumes...)
+
+	return &corev1.Pod{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      b.PodName(),
+			Namespace: b.Namespace(),
+			Labels:    b.Labels,
+
+			OwnerReferences: []metav1.OwnerReference{
+				*kmeta.NewControllerRef(b),
+			},
+		},
+		Spec: corev1.PodSpec{
+			// If the build fails, don't restart it.
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{
+				{
+					Name:            "nop",
+					Image:           config.NopImage,
+					ImagePullPolicy: "IfNotPresent",
+				},
+			},
+			InitContainers: []corev1.Container{
+				{
+					Name:            "creds-init",
+					Image:           config.CredsInitImage,
+					Args:            secretArgs,
+					ImagePullPolicy: "IfNotPresent",
+					VolumeMounts:    append(secretVolumeMounts, homeDirVolume), //home volume
+					Env: []corev1.EnvVar{
+						{
+							Name:  "HOME",
+							Value: "/builder/home",
+						},
+					},
+				},
+				{
+					Name:  "git-init",          //todo move from build-service?
+					Image: config.GitInitImage, // image
+					Args: []string{
+						"-url",
+						b.Spec.Source.Git.URL,
+						"-revision",
+						b.Spec.Source.Git.Revision,
+					},
+					Env: []corev1.EnvVar{
+						{
+							Name:  "HOME",
+							Value: "/builder/home",
+						},
+					},
+					ImagePullPolicy: "IfNotPresent",
+					WorkingDir:      "/workspace", //does this need to be in /workspace
+					VolumeMounts: []corev1.VolumeMount{
+						workspaceVolume,
+						homeDirVolume,
+					},
+				},
+
+				{
+					Name:  "prepare",
+					Image: config.BuildInitImage,
+					SecurityContext: &corev1.SecurityContext{
+						RunAsUser:  &root,
+						RunAsGroup: &root,
+					},
+					Env: []corev1.EnvVar{
+						{
+							Name:  "BUILDER",
+							Value: b.Spec.Builder,
+						},
+						{
+							Name:  "PLATFORM_ENV_VARS",
+							Value: envVars,
+						},
+						{
+							Name:  "HOME",
+							Value: "/builder/home",
+						},
+					},
+					Resources: b.Spec.Resources,
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      layersDirName,
+							MountPath: "/layersDir", //layers is already in buildpack built image
+						},
+						{
+							Name:      cacheDirName,
+							MountPath: "/cache",
+						},
+						{
+							Name:      platformDir,
+							MountPath: "/platform",
+						},
+						workspaceVolume,
+						homeDirVolume,
+					},
+					ImagePullPolicy: "IfNotPresent",
+				},
+				{
+					Name:      "detect",
+					Image:     b.Spec.Builder,
+					Resources: b.Spec.Resources,
+					Command:   []string{"/lifecycle/detector"},
+					Args: []string{
+						"-app=/workspace",
+						"-group=/layers/group.toml",
+						"-plan=/layers/plan.toml",
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      layersDirName,
+							MountPath: "/layers",
+						},
+						{
+							Name:      platformDir,
+							MountPath: "/platform",
+						},
+						workspaceVolume,
+					},
+					ImagePullPolicy: "IfNotPresent",
+				},
+				{
+					Name:      "restore",
+					Image:     b.Spec.Builder,
+					Resources: b.Spec.Resources,
+					Command:   []string{"/lifecycle/restorer"},
+					Args: []string{
+						"-group=/layers/group.toml",
+						"-layers=/layers",
+						"-path=/cache",
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      layersDirName,
+							MountPath: "/layers",
+						},
+						{
+							Name:      cacheDirName,
+							MountPath: "/cache",
+						},
+					},
+					ImagePullPolicy: "IfNotPresent",
+				},
+				{
+					Name:      "analyze",
+					Image:     b.Spec.Builder,
+					Resources: b.Spec.Resources,
+					Command:   []string{"/lifecycle/analyzer"},
+					Args: []string{
+						"-layers=/layers",
+						"-helpers=false",
+						"-group=/layers/group.toml",
+						"-analyzed=/layers/analyzed.toml",
+						b.Spec.Image,
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      layersDirName,
+							MountPath: "/layers",
+						},
+						workspaceVolume,
+						homeDirVolume,
+					},
+					Env: []corev1.EnvVar{
+						{
+							Name:  "HOME",
+							Value: "/builder/home",
+						},
+					},
+					ImagePullPolicy: "IfNotPresent",
+				},
+				{
+					Name:      "build",
+					Image:     b.Spec.Builder,
+					Resources: b.Spec.Resources,
+					Command:   []string{"/lifecycle/builder"},
+					Args: []string{
+						"-layers=/layers",
+						"-app=/workspace",
+						"-group=/layers/group.toml",
+						"-plan=/layers/plan.toml",
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      layersDirName,
+							MountPath: "/layers",
+						},
+						{
+							Name:      platformDir,
+							MountPath: "/platform",
+						},
+						workspaceVolume,
+					},
+					ImagePullPolicy: "IfNotPresent",
+				},
+				{
+					Name:      "export",
+					Image:     b.Spec.Builder,
+					Resources: b.Spec.Resources,
+					Command:   []string{"/lifecycle/exporter"},
+					Args:      buildExporterArgs(b),
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      layersDirName,
+							MountPath: "/layers",
+						},
+						workspaceVolume,
+						homeDirVolume,
+					},
+					Env: []corev1.EnvVar{
+						{
+							Name:  "HOME",
+							Value: "/builder/home",
+						},
+					},
+					ImagePullPolicy: "IfNotPresent",
+				},
+				{
+					Name:      "cache",
+					Image:     b.Spec.Builder,
+					Resources: b.Spec.Resources,
+					Command:   []string{"/lifecycle/cacher"},
+					Args: []string{
+						"-group=/layers/group.toml",
+						"-layers=/layers",
+						"-path=/cache",
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      layersDirName,
+							MountPath: "/layers",
+						},
+						{
+							Name:      cacheDirName,
+							MountPath: "/cache",
+						},
+					},
+					ImagePullPolicy: "IfNotPresent",
+				},
+			},
+			ServiceAccountName: b.Spec.ServiceAccount,
+			Volumes:            volumes,
+		},
+	}, nil
+}
+
+func buildExporterArgs(build *Build) []string {
+	args := []string{
+		"-layers=/layers",
+		"-helpers=false",
+		"-app=/workspace",
+		"-group=/layers/group.toml",
+		"-analyzed=/layers/analyzed.toml",
+		build.Spec.Image}
+	args = append(args, build.Spec.AdditionalImageNames...)
+	return args
+}
+
+func (b *Build) cacheVolume() corev1.VolumeSource {
+	if b.Spec.CacheName != "" {
+		return corev1.VolumeSource{
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: b.Spec.CacheName},
+		}
+	} else {
+		return corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		}
+	}
+}
+
+func isBuildServiceSecret(secret corev1.Secret) bool {
+	return secret.Annotations[GITSecretAnnotationPrefix] != "" || secret.Annotations[DOCKERSecretAnnotationPrefix] != ""
+}
+
+func (b *Build) secretVolumesArgs(secrets []corev1.Secret) ([]corev1.Volume, []corev1.VolumeMount, []string, error) {
+	var (
+		volumes      []corev1.Volume
+		volumeMounts []corev1.VolumeMount
+		args         []string
+	)
+	for _, secret := range secrets {
+		if !isBuildServiceSecret(secret) {
+			continue
+		}
+		volumeName := fmt.Sprintf(SecretTemplateName, secret.Name)
+
+		volumes = append(volumes, corev1.Volume{
+			Name: volumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: secret.Name,
+				},
+			},
+		})
+
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      volumeName,
+			MountPath: fmt.Sprintf(SecretPathName, secret.Name),
+		})
+
+		annotatedUrl := secret.Annotations[DOCKERSecretAnnotationPrefix]
+		secretType := "docker"
+		if secret.Annotations[GITSecretAnnotationPrefix] != "" {
+			annotatedUrl = secret.Annotations[GITSecretAnnotationPrefix]
+			secretType = "git"
+		}
+
+		args = append(args, fmt.Sprintf("-basic-%s=%s=%s", secretType, secret.Name, annotatedUrl))
+	}
+	return volumes, volumeMounts, args, nil
+}

--- a/pkg/apis/build/v1alpha1/build_pod_test.go
+++ b/pkg/apis/build/v1alpha1/build_pod_test.go
@@ -1,0 +1,379 @@
+package v1alpha1_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/knative/pkg/kmeta"
+	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/pivotal/build-service-system/pkg/apis/build/v1alpha1"
+)
+
+func TestBuildPod(t *testing.T) {
+	spec.Run(t, "Test Build Pod", testBuildPod)
+}
+
+func testBuildPod(t *testing.T, when spec.G, it spec.S) {
+	const (
+		namespace      = "some-namespace"
+		buildName      = "build-name"
+		builderImage   = "somebuilder/123"
+		serviceAccount = "someserviceaccount"
+	)
+	resources := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("2"),
+			corev1.ResourceMemory: resource.MustParse("256M"),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("1"),
+			corev1.ResourceMemory: resource.MustParse("128M"),
+		},
+	}
+
+	build := &v1alpha1.Build{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      buildName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"some/label": "to-pass-through",
+			},
+		},
+		Spec: v1alpha1.BuildSpec{
+			Image:          "someimage/name",
+			ServiceAccount: serviceAccount,
+			Builder:        builderImage,
+			Env: []corev1.EnvVar{
+				{Name: "keyA", Value: "valueA"},
+				{Name: "keyB", Value: "valueB"},
+			},
+			Resources: resources,
+			Source: v1alpha1.Source{
+				Git: v1alpha1.Git{
+					URL:      "giturl.com/git.git",
+					Revision: "gitrev1234",
+				},
+			},
+			CacheName:            "some-cache-name",
+			AdditionalImageNames: []string{"someimage/name:tag2", "someimage/name:tag3"},
+		},
+	}
+
+	secrets := []corev1.Secret{
+		{
+			TypeMeta: metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "git-secret-1",
+				Annotations: map[string]string{
+					v1alpha1.GITSecretAnnotationPrefix: "https://github.com",
+				},
+			},
+			StringData: map[string]string{
+				"username": "username",
+				"password": "password",
+			},
+			Type: corev1.SecretTypeBasicAuth,
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "docker-secret-1",
+				Annotations: map[string]string{
+					v1alpha1.DOCKERSecretAnnotationPrefix: "acr.io",
+				},
+			},
+			Type: corev1.SecretTypeBasicAuth,
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "random-secret-1",
+			},
+			Type: corev1.SecretTypeBasicAuth,
+		},
+	}
+	config := v1alpha1.BuildPodConfig{
+		GitInitImage:   "git/init:image",
+		BuildInitImage: "build/init:image",
+		CredsInitImage: "creds/init:image",
+		NopImage:       "no/op:image",
+	}
+
+	when("BuildPod", func() {
+		it("creates a pod with a builder owner reference", func() {
+			pod, err := build.BuildPod(config, secrets)
+			require.NoError(t, err)
+
+			assert.Equal(t, pod.ObjectMeta, metav1.ObjectMeta{
+				Name:      build.PodName(),
+				Namespace: namespace,
+				Labels: map[string]string{
+					"some/label": "to-pass-through",
+				},
+				OwnerReferences: []metav1.OwnerReference{
+					*kmeta.NewControllerRef(build),
+				},
+			})
+		})
+
+		it("creates a pod with a correct service account", func() {
+			pod, err := build.BuildPod(config, secrets)
+			require.NoError(t, err)
+
+			assert.Equal(t, serviceAccount, pod.Spec.ServiceAccountName)
+		})
+
+		it("creates init containers with all the build steps", func() {
+			pod, err := build.BuildPod(config, secrets)
+			require.NoError(t, err)
+
+			assert.Len(t, pod.Spec.InitContainers, len([]string{
+				"creds-init",
+				"git-init",
+				"prepare",
+				"detect",
+				"restore",
+				"analyze",
+				"build",
+				"export",
+				"cache",
+			}))
+		})
+
+		it("configures creds init", func() {
+			pod, err := build.BuildPod(config, secrets)
+			require.NoError(t, err)
+
+			assert.Equal(t, pod.Spec.InitContainers[0].Name, "creds-init")
+			assert.Equal(t, pod.Spec.InitContainers[0].Image, config.CredsInitImage)
+			assert.Equal(t, []string{
+				"-basic-git=git-secret-1=https://github.com",
+				"-basic-docker=docker-secret-1=acr.io",
+			}, pod.Spec.InitContainers[0].Args)
+			assert.Equal(t, []corev1.VolumeMount{
+				{
+					Name:      "secret-volume-git-secret-1",
+					MountPath: "/var/build-secrets/git-secret-1",
+				},
+				{
+					Name:      "secret-volume-docker-secret-1",
+					MountPath: "/var/build-secrets/docker-secret-1",
+				},
+				{
+					Name:      "home-dir",
+					MountPath: "/builder/home",
+				},
+			}, pod.Spec.InitContainers[0].VolumeMounts)
+		})
+
+		it("configures git init with the build's source", func() {
+			pod, err := build.BuildPod(config, secrets)
+			require.NoError(t, err)
+
+			assert.Equal(t, pod.Spec.InitContainers[1].Name, "git-init")
+			assert.Equal(t, pod.Spec.InitContainers[1].Image, config.GitInitImage)
+			assert.Equal(t, pod.Spec.InitContainers[1].Args, []string{
+				"-url",
+				build.Spec.Source.Git.URL,
+				"-revision",
+				build.Spec.Source.Git.Revision,
+			})
+		})
+
+		it("configures prepare step with the build setup", func() {
+			pod, err := build.BuildPod(config, secrets)
+			require.NoError(t, err)
+
+			assert.Equal(t, pod.Spec.InitContainers[2].Name, "prepare")
+			assert.Equal(t, pod.Spec.InitContainers[2].Image, config.BuildInitImage)
+			assert.Equal(t, pod.Spec.InitContainers[2].Env, []corev1.EnvVar{
+				{
+					Name:  "BUILDER",
+					Value: build.Spec.Builder,
+				},
+				{
+					Name:  "PLATFORM_ENV_VARS",
+					Value: `[{"name":"keyA","value":"valueA"},{"name":"keyB","value":"valueB"}]`,
+				},
+				{
+					Name:  "HOME",
+					Value: "/builder/home",
+				},
+			})
+			assert.Len(t, pod.Spec.InitContainers[2].VolumeMounts, len([]string{
+				"layers-dir",
+				"cache-dir",
+				"platform-dir",
+				"workspace-dir",
+				"home-dir",
+			}))
+		})
+
+		it("configures detect step", func() {
+			pod, err := build.BuildPod(config, secrets)
+			require.NoError(t, err)
+
+			assert.Equal(t, pod.Spec.InitContainers[3].Name, "detect")
+			assert.Equal(t, pod.Spec.InitContainers[3].Image, builderImage)
+			assert.Len(t, pod.Spec.InitContainers[3].VolumeMounts, len([]string{
+				"layers-dir",
+				"platform-dir",
+				"workspace-dir",
+			}))
+		})
+
+		it("configures restore step", func() {
+			pod, err := build.BuildPod(config, secrets)
+			require.NoError(t, err)
+
+			assert.Equal(t, pod.Spec.InitContainers[4].Name, "restore")
+			assert.Equal(t, pod.Spec.InitContainers[4].Image, builderImage)
+			assert.Len(t, pod.Spec.InitContainers[4].VolumeMounts, len([]string{
+				"layers-dir",
+				"home-dir",
+			}))
+		})
+
+		it("configures analyze step", func() {
+			pod, err := build.BuildPod(config, secrets)
+			require.NoError(t, err)
+
+			assert.Equal(t, pod.Spec.InitContainers[5].Name, "analyze")
+			assert.Equal(t, pod.Spec.InitContainers[5].Image, builderImage)
+			assert.Len(t, pod.Spec.InitContainers[5].VolumeMounts, len([]string{
+				"layers-dir",
+				"workspace-dir",
+				"home-dir",
+			}))
+			assert.Equal(t, []string{
+				"-layers=/layers",
+				"-helpers=false",
+				"-group=/layers/group.toml",
+				"-analyzed=/layers/analyzed.toml",
+				build.Spec.Image,
+			}, pod.Spec.InitContainers[5].Args)
+		})
+
+		it("configures build step", func() {
+			pod, err := build.BuildPod(config, secrets)
+			require.NoError(t, err)
+
+			assert.Equal(t, pod.Spec.InitContainers[6].Name, "build")
+			assert.Equal(t, pod.Spec.InitContainers[6].Image, builderImage)
+			assert.Len(t, pod.Spec.InitContainers[6].VolumeMounts, len([]string{
+				"layers-dir",
+				"platform-dir",
+				"workspace-dir",
+			}))
+		})
+
+		it("configures export step", func() {
+			pod, err := build.BuildPod(config, secrets)
+			require.NoError(t, err)
+
+			assert.Equal(t, pod.Spec.InitContainers[7].Name, "export")
+			assert.Equal(t, pod.Spec.InitContainers[7].Image, builderImage)
+			assert.Len(t, pod.Spec.InitContainers[7].VolumeMounts, len([]string{
+				"layers-dir",
+				"workspace-dir",
+				"home-dir",
+			}))
+			assert.Equal(t, []string{
+				"-layers=/layers",
+				"-helpers=false",
+				"-app=/workspace",
+				"-group=/layers/group.toml",
+				"-analyzed=/layers/analyzed.toml",
+				build.Spec.Image,
+				"someimage/name:tag2",
+				"someimage/name:tag3",
+			}, pod.Spec.InitContainers[7].Args)
+		})
+
+		it("configures cache step", func() {
+			pod, err := build.BuildPod(config, secrets)
+			require.NoError(t, err)
+
+			assert.Equal(t, pod.Spec.InitContainers[8].Name, "cache")
+			assert.Equal(t, pod.Spec.InitContainers[8].Image, builderImage)
+			assert.Len(t, pod.Spec.InitContainers[8].VolumeMounts, len([]string{
+				"layers-dir",
+				"cache-dir",
+			}))
+		})
+
+		it("configures the builder image and resources in all lifecycle steps", func() {
+			pod, err := build.BuildPod(config, secrets)
+			require.NoError(t, err)
+
+			for _, container := range pod.Spec.InitContainers {
+				if container.Name != "creds-init" && container.Name != "git-init" && container.Name != "prepare" {
+					assert.Equal(t, builderImage, container.Image, fmt.Sprintf("image on container '%s'", container.Name))
+					assert.Equal(t, resources, container.Resources, fmt.Sprintf("resources on container '%s'", container.Name))
+				}
+			}
+		})
+
+		it("creates a pod with reusable cache when name is provided", func() {
+			pod, err := build.BuildPod(config, nil)
+			require.NoError(t, err)
+
+			require.Len(t, pod.Spec.Volumes, 5)
+			assert.Equal(t, corev1.Volume{
+				Name: "empty-dir",
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "some-cache-name"},
+				},
+			}, pod.Spec.Volumes[0])
+		})
+
+		it("creates a pod with empty cache when no name is provided", func() {
+			build.Spec.CacheName = ""
+			pod, err := build.BuildPod(config, nil)
+			require.NoError(t, err)
+
+			require.Len(t, pod.Spec.Volumes, 5)
+			assert.Equal(t, corev1.Volume{
+				Name: "empty-dir",
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			}, pod.Spec.Volumes[0])
+		})
+
+		it("attach volumes for secrets", func() {
+			pod, err := build.BuildPod(config, secrets)
+			require.NoError(t, err)
+
+			assertSecretPresent(t, pod, "git-secret-1")
+			assertSecretPresent(t, pod, "docker-secret-1")
+			assertSecretNotPresent(t, pod, "random-secret-1")
+		})
+	})
+}
+
+func assertSecretPresent(t *testing.T, pod *corev1.Pod, secretName string) {
+	assert.True(t, isSecretPresent(t, pod, secretName), fmt.Sprintf("secret '%s' not present", secretName))
+}
+
+func assertSecretNotPresent(t *testing.T, pod *corev1.Pod, secretName string) {
+	assert.False(t, isSecretPresent(t, pod, secretName), fmt.Sprintf("secret '%s' not present", secretName))
+}
+
+func isSecretPresent(t *testing.T, pod *corev1.Pod, secretName string) bool {
+	for _, volume := range pod.Spec.Volumes {
+		if volume.Name == fmt.Sprintf(v1alpha1.SecretTemplateName, secretName) {
+			assert.Equal(t, corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: secretName,
+				},
+			}, volume.VolumeSource)
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/buildpod/generator.go
+++ b/pkg/buildpod/generator.go
@@ -1,0 +1,39 @@
+package buildpod
+
+import (
+	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sclient "k8s.io/client-go/kubernetes"
+
+	"github.com/pivotal/build-service-system/pkg/apis/build/v1alpha1"
+)
+
+type Generator struct {
+	BuildPodConfig v1alpha1.BuildPodConfig
+	K8sClient      k8sclient.Interface
+}
+
+func (g *Generator) Generate(build *v1alpha1.Build) (*v1.Pod, error) {
+	secrets, err := g.getBuildSecrets(build)
+	if err != nil {
+		return nil, err
+	}
+	return build.BuildPod(g.BuildPodConfig, secrets)
+}
+
+func (g *Generator) getBuildSecrets(build *v1alpha1.Build) ([]corev1.Secret, error) {
+	var secrets []corev1.Secret
+	serviceAccount, err := g.K8sClient.CoreV1().ServiceAccounts(build.Namespace()).Get(build.ServiceAccount(), metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	for _, secretRef := range serviceAccount.Secrets {
+		secret, err := g.K8sClient.CoreV1().Secrets(build.Namespace()).Get(secretRef.Name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		secrets = append(secrets, *secret)
+	}
+	return secrets, nil
+}

--- a/pkg/buildpod/generator_test.go
+++ b/pkg/buildpod/generator_test.go
@@ -1,0 +1,142 @@
+package buildpod_test
+
+import (
+	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/pivotal/build-service-system/pkg/apis/build/v1alpha1"
+	"github.com/pivotal/build-service-system/pkg/buildpod"
+)
+
+func TestGenerator(t *testing.T) {
+	spec.Run(t, "Generator", testGenerator)
+}
+
+func testGenerator(t *testing.T, when spec.G, it spec.S) {
+	when("Generate", func() {
+		const serviceAccountName = "serviceAccountName"
+
+		gitSecret := &corev1.Secret{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "git-secret-1",
+				Annotations: map[string]string{
+					v1alpha1.GITSecretAnnotationPrefix: "https://github.com",
+				},
+			},
+			StringData: map[string]string{
+				"username": "username",
+				"password": "password",
+			},
+			Type: corev1.SecretTypeBasicAuth,
+		}
+
+		dockerSecret := &corev1.Secret{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "docker-secret-1",
+				Annotations: map[string]string{
+					v1alpha1.DOCKERSecretAnnotationPrefix: "https://gcr.io",
+				},
+			},
+			StringData: map[string]string{
+				"username": "username",
+				"password": "password",
+			},
+			Type: corev1.SecretTypeBasicAuth,
+		}
+
+		ignoredSecret := &corev1.Secret{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "ignored-secret",
+			},
+			StringData: map[string]string{
+				"username": "username",
+				"password": "password",
+			},
+			Type: corev1.SecretTypeBasicAuth,
+		}
+
+		serviceAccount := &corev1.ServiceAccount{
+			ObjectMeta: v1.ObjectMeta{
+				Namespace: "namespace",
+				Name:      serviceAccountName,
+			},
+			Secrets: []corev1.ObjectReference{
+				{
+					Kind: "secret",
+					Name: "git-secret-1",
+				},
+				{
+					Kind: "secret",
+					Name: "docker-secret-1",
+				},
+			},
+		}
+		fakeK8sClient := fake.NewSimpleClientset(serviceAccount, dockerSecret, gitSecret, ignoredSecret)
+
+		it("returns pod config with secrets on build's service account", func() {
+
+			buildPodConfig := v1alpha1.BuildPodConfig{
+				GitInitImage:   "git/init:image",
+				BuildInitImage: "build/init:image",
+				CredsInitImage: "creds/init:image",
+				NopImage:       "no/op:image",
+			}
+			generator := &buildpod.Generator{
+				BuildPodConfig: buildPodConfig,
+				K8sClient:      fakeK8sClient,
+			}
+
+			build := &v1alpha1.Build{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "simple-build",
+				},
+				Spec: v1alpha1.BuildSpec{
+					Image:          "image/name",
+					Builder:        "builder/name",
+					ServiceAccount: serviceAccountName,
+					Source: v1alpha1.Source{
+						Git: v1alpha1.Git{
+							URL:      "http://www.google.com",
+							Revision: "master",
+						},
+					},
+					CacheName: "some-cache-name",
+					AdditionalImageNames: []string{
+						"additional/names",
+					},
+					Env: []corev1.EnvVar{
+						{
+							Name:  "ENV",
+							Value: "NAME",
+						},
+					},
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("2"),
+							corev1.ResourceMemory: resource.MustParse("256M"),
+						},
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse("128M"),
+						},
+					},
+				},
+			}
+			pod, err := generator.Generate(build)
+			require.NoError(t, err)
+
+			expectedPod, err := build.BuildPod(buildPodConfig, []corev1.Secret{
+				*gitSecret,
+				*dockerSecret,
+			})
+			require.NoError(t, err)
+			require.Equal(t, expectedPod, pod)
+		})
+	})
+}

--- a/pkg/git/k8s_git_keychain.go
+++ b/pkg/git/k8s_git_keychain.go
@@ -13,12 +13,10 @@ type K8sGitKeychain struct {
 	secretManager secret.SecretManager
 }
 
-const gitKNativeKey = "build.knative.dev/git-0"
-
 func NewK8sGitKeychain(k8sClient k8sclient.Interface) *K8sGitKeychain {
 	return &K8sGitKeychain{secretManager: secret.SecretManager{
 		Client:        k8sClient,
-		AnnotationKey: gitKNativeKey,
+		AnnotationKey: v1alpha1.GITSecretAnnotationPrefix,
 		Matcher:       gitUrlMatcher{},
 	}}
 }

--- a/pkg/reconciler/testhelpers/listers.go
+++ b/pkg/reconciler/testhelpers/listers.go
@@ -69,3 +69,7 @@ func (l *Listers) GetSourceResolverLister() v1alpha1Listers.SourceResolverLister
 func (l *Listers) GetPersistentVolumeClaimLister() corev1listers.PersistentVolumeClaimLister {
 	return corev1listers.NewPersistentVolumeClaimLister(l.indexerFor(&corev1.PersistentVolumeClaim{}))
 }
+
+func (l *Listers) GetPodLister() corev1listers.PodLister {
+	return corev1listers.NewPodLister(l.indexerFor(&corev1.Pod{}))
+}

--- a/pkg/registry/secrets_keychain.go
+++ b/pkg/registry/secrets_keychain.go
@@ -8,10 +8,9 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	k8sclient "k8s.io/client-go/kubernetes"
 
+	"github.com/pivotal/build-service-system/pkg/apis/build/v1alpha1"
 	"github.com/pivotal/build-service-system/pkg/secret"
 )
-
-const KnativeRegistryUrl = "build.knative.dev/docker-0"
 
 type SecretKeychainFactory struct {
 	secretManager *secret.SecretManager
@@ -21,7 +20,7 @@ func NewSecretKeychainFactory(client k8sclient.Interface) *SecretKeychainFactory
 	return &SecretKeychainFactory{
 		secretManager: &secret.SecretManager{
 			Client:        client,
-			AnnotationKey: KnativeRegistryUrl,
+			AnnotationKey: v1alpha1.DOCKERSecretAnnotationPrefix,
 			Matcher:       registryMatcher{},
 		},
 	}

--- a/pkg/secret/testhelpers/save_secrets.go
+++ b/pkg/secret/testhelpers/save_secrets.go
@@ -6,15 +6,16 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	k8sclient "k8s.io/client-go/kubernetes"
 
+	"github.com/pivotal/build-service-system/pkg/apis/build/v1alpha1"
 	"github.com/pivotal/build-service-system/pkg/secret"
 )
 
 func SaveGitSecrets(client k8sclient.Interface, namespace, serviceAccount string, users []secret.URLAndUser) error {
-	return saveSecrets(client, namespace, serviceAccount, users, "build.knative.dev/git-0")
+	return saveSecrets(client, namespace, serviceAccount, users, v1alpha1.GITSecretAnnotationPrefix)
 }
 
 func SaveDockerSecrets(client k8sclient.Interface, namespace, serviceAccount string, users []secret.URLAndUser) error {
-	return saveSecrets(client, namespace, serviceAccount, users, "build.knative.dev/docker-0")
+	return saveSecrets(client, namespace, serviceAccount, users, v1alpha1.DOCKERSecretAnnotationPrefix)
 }
 
 func saveSecrets(client k8sclient.Interface, namespace, serviceAccount string, users []secret.URLAndUser, annotationKey string) error {

--- a/test/execute_build_test.go
+++ b/test/execute_build_test.go
@@ -85,7 +85,7 @@ func testCreateImage(t *testing.T, when spec.G, it spec.S) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: dockerSecret,
 					Annotations: map[string]string{
-						"build.knative.dev/docker-0": reference.Context().RegistryStr(),
+						"build.pivotal.io/docker": reference.Context().RegistryStr(),
 					},
 				},
 				StringData: map[string]string{


### PR DESCRIPTION
- Replace Knative Build usage by creating a Pod that defines the build
- lifecycle build step does not have access to credentials
- Use working dir of builder instead of setting it to /workspace

Signed-off-by: Matthew McNew <mmcnew@pivotal.io>