### PR TITLE
Rename image.spec.image to image.spec.tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ kubectl cluster-info # ensure you have access to a cluster
     metadata:
       name: sample-image
     spec:
+      tag: gcr.io/project-name/app
       serviceAccount: service-account
       builderRef: sample-builder
-      image: gcr.io/project-name/app
       cacheSize: "1.5Gi"
       failedBuildHistoryLimit: 5
       successBuildHistoryLimit: 5

--- a/pkg/apis/build/v1alpha1/build_pod.go
+++ b/pkg/apis/build/v1alpha1/build_pod.go
@@ -201,7 +201,7 @@ func (b *Build) BuildPod(config BuildPodConfig, secrets []corev1.Secret) (*corev
 						"-helpers=false",
 						"-group=/layers/group.toml",
 						"-analyzed=/layers/analyzed.toml",
-						b.Spec.Image,
+						b.Spec.Tag,
 					},
 					VolumeMounts: []corev1.VolumeMount{
 						layersVolume,
@@ -277,7 +277,7 @@ func buildExporterArgs(build *Build) []string {
 		"-app=/workspace",
 		"-group=/layers/group.toml",
 		"-analyzed=/layers/analyzed.toml",
-		build.Spec.Image}
+		build.Spec.Tag}
 	args = append(args, build.Spec.AdditionalImageNames...)
 	return args
 }

--- a/pkg/apis/build/v1alpha1/build_pod_test.go
+++ b/pkg/apis/build/v1alpha1/build_pod_test.go
@@ -46,7 +46,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 			},
 		},
 		Spec: v1alpha1.BuildSpec{
-			Image:          "someimage/name",
+			Tag:            "someimage/name",
 			ServiceAccount: serviceAccount,
 			Builder:        builderImage,
 			Env: []corev1.EnvVar{
@@ -254,7 +254,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 				"-helpers=false",
 				"-group=/layers/group.toml",
 				"-analyzed=/layers/analyzed.toml",
-				build.Spec.Image,
+				build.Spec.Tag,
 			}, pod.Spec.InitContainers[5].Args)
 		})
 
@@ -288,7 +288,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 				"-app=/workspace",
 				"-group=/layers/group.toml",
 				"-analyzed=/layers/analyzed.toml",
-				build.Spec.Image,
+				build.Spec.Tag,
 				"someimage/name:tag2",
 				"someimage/name:tag3",
 			}, pod.Spec.InitContainers[7].Args)

--- a/pkg/apis/build/v1alpha1/build_types.go
+++ b/pkg/apis/build/v1alpha1/build_types.go
@@ -43,7 +43,7 @@ var (
 )
 
 type BuildSpec struct {
-	Image                string                      `json:"image"`
+	Tag                  string                      `json:"tag"`
 	Builder              string                      `json:"builder"`
 	ServiceAccount       string                      `json:"serviceAccount"`
 	Source               Source                      `json:"source"`
@@ -79,8 +79,8 @@ func (b *Build) ServiceAccount() string {
 	return b.Spec.ServiceAccount
 }
 
-func (b *Build) RepoName() string {
-	return b.Spec.Image
+func (b *Build) Tag() string {
+	return b.Spec.Tag
 }
 
 func (b *Build) Namespace() string {
@@ -111,7 +111,7 @@ func (b *Build) BuiltImage() string {
 		return ""
 	}
 
-	return b.Spec.Image + "@" + b.Status.SHA
+	return b.Spec.Tag + "@" + b.Status.SHA
 }
 
 func (b *Build) IsSuccess() bool {

--- a/pkg/apis/build/v1alpha1/image_builds.go
+++ b/pkg/apis/build/v1alpha1/image_builds.go
@@ -32,7 +32,7 @@ func (im *Image) buildNeeded(lastBuild *Build, sourceResolver *SourceResolver, b
 		return []string{BuildReasonConfig}, true
 	}
 
-	if im.Spec.Image != lastBuild.Spec.Image {
+	if im.Spec.Tag != lastBuild.Spec.Tag {
 		return []string{BuildReasonConfig}, true
 	}
 
@@ -82,7 +82,7 @@ func (im *Image) build(sourceResolver *SourceResolver, builder *Builder, reasons
 			},
 		},
 		Spec: BuildSpec{
-			Image:          im.Spec.Image,
+			Tag:            im.Spec.Tag,
 			Builder:        builder.Spec.Image,
 			Env:            im.Spec.Build.Env,
 			Resources:      im.Spec.Build.Resources,
@@ -163,7 +163,7 @@ func (im *Image) generateImageNames(buildNumber string) []string {
 	}
 	now := time.Now()
 
-	tag, err := name.NewTag(im.Spec.Image, name.WeakValidation)
+	tag, err := name.NewTag(im.Spec.Tag, name.WeakValidation)
 	if err != nil {
 		// We assume that if the Image Name cannot be parsed the image will not be successfully built
 		// in this case we can just ignore any additional image names

--- a/pkg/apis/build/v1alpha1/image_builds_test.go
+++ b/pkg/apis/build/v1alpha1/image_builds_test.go
@@ -22,7 +22,7 @@ func testImageBuilds(t *testing.T, when spec.G, it spec.S) {
 			Name: "image-name",
 		},
 		Spec: ImageSpec{
-			Image:          "some/image",
+			Tag:            "some/image",
 			ServiceAccount: "some/service-account",
 			BuilderRef:     "some/builder",
 			Build: ImageBuild{
@@ -66,7 +66,7 @@ func testImageBuilds(t *testing.T, when spec.G, it spec.S) {
 			Name: "image-name",
 		},
 		Spec: BuildSpec{
-			Image:          "some/image",
+			Tag:            "some/image",
 			Builder:        "some/builder",
 			ServiceAccount: "some/serviceaccount",
 			Source: Source{
@@ -112,7 +112,7 @@ func testImageBuilds(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("true for different image", func() {
-			image.Spec.Image = "different"
+			image.Spec.Tag = "different"
 
 			reasons, needed := image.buildNeeded(build, sourceResolver, builder)
 			assert.True(t, needed)
@@ -303,7 +303,7 @@ func testImageBuilds(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("with excludes additional images names when explicitly disabled", func() {
-			image.Spec.Image = "imagename/foo:test"
+			image.Spec.Tag = "imagename/foo:test"
 			image.Spec.DisableAdditionalImageNames = true
 			build := image.build(sourceResolver, builder, []string{BuildReasonConfig}, 1)
 			require.Len(t, build.Spec.AdditionalImageNames, 0)
@@ -311,14 +311,14 @@ func testImageBuilds(t *testing.T, when spec.G, it spec.S) {
 
 		when("generates additional image names for a provided build number", func() {
 			it("with tag prefix if image name has a tag", func() {
-				image.Spec.Image = "gcr.io/imagename/foo:test"
+				image.Spec.Tag = "gcr.io/imagename/foo:test"
 				build := image.build(sourceResolver, builder, []string{BuildReasonConfig}, 45)
 				require.Len(t, build.Spec.AdditionalImageNames, 1)
 				require.Regexp(t, "gcr.io/imagename/foo:test-b45\\.\\d{8}\\.\\d{6}", build.Spec.AdditionalImageNames[0])
 			})
 
 			it("without tag prefix if image name has no provided tag", func() {
-				image.Spec.Image = "gcr.io/imagename/notags"
+				image.Spec.Tag = "gcr.io/imagename/notags"
 				build := image.build(sourceResolver, builder, []string{BuildReasonConfig}, 1)
 
 				require.Len(t, build.Spec.AdditionalImageNames, 1)
@@ -326,7 +326,7 @@ func testImageBuilds(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("without tag prefix if image name has the tag 'latest' provided", func() {
-				image.Spec.Image = "gcr.io/imagename/tagged:latest"
+				image.Spec.Tag = "gcr.io/imagename/tagged:latest"
 				build := image.build(sourceResolver, builder, []string{BuildReasonConfig}, 1)
 
 				require.Len(t, build.Spec.AdditionalImageNames, 1)

--- a/pkg/apis/build/v1alpha1/image_types.go
+++ b/pkg/apis/build/v1alpha1/image_types.go
@@ -36,7 +36,7 @@ type Image struct {
 }
 
 type ImageSpec struct {
-	Image                       string             `json:"image"`
+	Tag                         string             `json:"tag"`
 	BuilderRef                  string             `json:"builderRef"`
 	ServiceAccount              string             `json:"serviceAccount"`
 	Source                      Source             `json:"source"`

--- a/pkg/buildpod/generator_test.go
+++ b/pkg/buildpod/generator_test.go
@@ -97,7 +97,7 @@ func testGenerator(t *testing.T, when spec.G, it spec.S) {
 					Name: "simple-build",
 				},
 				Spec: v1alpha1.BuildSpec{
-					Image:          "image/name",
+					Tag:            "image/name",
 					Builder:        "builder/name",
 					ServiceAccount: serviceAccountName,
 					Source: v1alpha1.Source{

--- a/pkg/reconciler/v1alpha1/build/build_test.go
+++ b/pkg/reconciler/v1alpha1/build/build_test.go
@@ -86,7 +86,7 @@ func testBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 			Generation: originalGeneration,
 		},
 		Spec: v1alpha1.BuildSpec{
-			Image:          "someimage/name",
+			Tag:            "someimage/name",
 			ServiceAccount: serviceAccountName,
 			Builder:        "somebuilder/123",
 			Env: []corev1.EnvVar{

--- a/pkg/reconciler/v1alpha1/image/image_test.go
+++ b/pkg/reconciler/v1alpha1/image/image_test.go
@@ -84,7 +84,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 			},
 		},
 		Spec: v1alpha1.ImageSpec{
-			Image:          "some/image",
+			Tag:            "some/image",
 			ServiceAccount: serviceAccount,
 			BuilderRef:     builderName,
 			Source: v1alpha1.Source{
@@ -569,7 +569,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 								},
 							},
 							Spec: v1alpha1.BuildSpec{
-								Image:          image.Spec.Image,
+								Tag:            image.Spec.Tag,
 								Builder:        builder.Spec.Image,
 								ServiceAccount: image.Spec.ServiceAccount,
 								Source: v1alpha1.Source{
@@ -633,7 +633,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 								},
 							},
 							Spec: v1alpha1.BuildSpec{
-								Image:          image.Spec.Image,
+								Tag:            image.Spec.Tag,
 								Builder:        builder.Spec.Image,
 								ServiceAccount: image.Spec.ServiceAccount,
 								Source: v1alpha1.Source{
@@ -689,7 +689,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 								},
 							},
 							Spec: v1alpha1.BuildSpec{
-								Image:          image.Spec.Image,
+								Tag:            image.Spec.Tag,
 								Builder:        builder.Spec.Image,
 								ServiceAccount: "old-service-account",
 								Source: v1alpha1.Source{
@@ -731,7 +731,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 								},
 							},
 							Spec: v1alpha1.BuildSpec{
-								Image:          image.Spec.Image,
+								Tag:            image.Spec.Tag,
 								Builder:        builder.Spec.Image,
 								ServiceAccount: image.Spec.ServiceAccount,
 								Source: v1alpha1.Source{
@@ -796,7 +796,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 								},
 							},
 							Spec: v1alpha1.BuildSpec{
-								Image:          image.Spec.Image,
+								Tag:            image.Spec.Tag,
 								Builder:        builder.Spec.Image,
 								ServiceAccount: image.Spec.ServiceAccount,
 								Source: v1alpha1.Source{
@@ -838,7 +838,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 								},
 							},
 							Spec: v1alpha1.BuildSpec{
-								Image:          image.Spec.Image,
+								Tag:            image.Spec.Tag,
 								Builder:        builder.Spec.Image,
 								ServiceAccount: image.Spec.ServiceAccount,
 								Source: v1alpha1.Source{
@@ -910,7 +910,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 								},
 							},
 							Spec: v1alpha1.BuildSpec{
-								Image:          image.Spec.Image,
+								Tag:            image.Spec.Tag,
 								Builder:        builder.Spec.Image,
 								ServiceAccount: image.Spec.ServiceAccount,
 								Source: v1alpha1.Source{
@@ -958,7 +958,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 								},
 							},
 							Spec: v1alpha1.BuildSpec{
-								Image:          image.Spec.Image,
+								Tag:            image.Spec.Tag,
 								Builder:        builder.Spec.Image,
 								ServiceAccount: image.Spec.ServiceAccount,
 								Source: v1alpha1.Source{
@@ -1015,7 +1015,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 								},
 							},
 							Spec: v1alpha1.BuildSpec{
-								Image:          image.Spec.Image,
+								Tag:            image.Spec.Tag,
 								Builder:        builder.Spec.Image,
 								ServiceAccount: "old-service-account",
 								Source: v1alpha1.Source{
@@ -1066,7 +1066,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 								},
 							},
 							Spec: v1alpha1.BuildSpec{
-								Image:          image.Spec.Image,
+								Tag:            image.Spec.Tag,
 								Builder:        builder.Spec.Image,
 								ServiceAccount: image.Spec.ServiceAccount,
 								Source: v1alpha1.Source{
@@ -1239,7 +1239,7 @@ func builds(image *v1alpha1.Image, sourceResolver *v1alpha1.SourceResolver, coun
 				CreationTimestamp: metav1.NewTime(time.Now().Add(time.Duration(i) * time.Minute)),
 			},
 			Spec: v1alpha1.BuildSpec{
-				Image:          image.Spec.Image,
+				Tag:            image.Spec.Tag,
 				Builder:        "some/builder",
 				ServiceAccount: image.Spec.ServiceAccount,
 				Source: v1alpha1.Source{

--- a/pkg/registry/image_factory.go
+++ b/pkg/registry/image_factory.go
@@ -13,8 +13,8 @@ type ImageFactory struct {
 }
 
 func (f *ImageFactory) NewRemote(imageRef ImageRef) (RemoteImage, error) {
-	remote, err := imgutil.NewRemoteImage(imageRef.RepoName(), f.KeychainFactory.KeychainForImageRef(imageRef))
-	return remote, errors.Wrapf(err, "could not create remote image from ref %s", imageRef.RepoName())
+	remote, err := imgutil.NewRemoteImage(imageRef.Tag(), f.KeychainFactory.KeychainForImageRef(imageRef))
+	return remote, errors.Wrapf(err, "could not create remote image from ref %s", imageRef.Tag())
 }
 
 type KeychainFactory interface {
@@ -24,7 +24,7 @@ type KeychainFactory interface {
 type ImageRef interface {
 	ServiceAccount() string
 	Namespace() string
-	RepoName() string
+	Tag() string
 }
 
 type noAuthImageRef struct {
@@ -35,7 +35,7 @@ func NewNoAuthImageRef(repoName string) *noAuthImageRef {
 	return &noAuthImageRef{repoName: repoName}
 }
 
-func (na *noAuthImageRef) RepoName() string {
+func (na *noAuthImageRef) Tag() string {
 	return na.repoName
 }
 

--- a/pkg/registry/secrets_keychain_test.go
+++ b/pkg/registry/secrets_keychain_test.go
@@ -98,7 +98,7 @@ func (f *fakeImageRef) Namespace() string {
 	return f.namespace
 }
 
-func (f *fakeImageRef) RepoName() string {
+func (f *fakeImageRef) Tag() string {
 	return "NOT-NEEDED"
 }
 

--- a/samples/build.yaml
+++ b/samples/build.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   serviceAccount: serviceaccount
   builder: cloudfoundry/cnb
-  image: sample/image
+  tag: sample/image
   source:
     git:
       url: https://github.com/buildpack/sample-java-app.git

--- a/samples/image.yaml
+++ b/samples/image.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample
 spec:
   builderRef: sample-builder
-  image: registry.default.svc.cluster.local:5000/sample/image
+  tag: registry.default.svc.cluster.local:5000/sample/image
   source:
     git:
       url: https://github.com/buildpack/sample-java-app.git

--- a/test/execute_build_test.go
+++ b/test/execute_build_test.go
@@ -134,7 +134,7 @@ func testCreateImage(t *testing.T, when spec.G, it spec.S) {
 					Name: imageName,
 				},
 				Spec: v1alpha1.ImageSpec{
-					Image:          cfg.imageTag,
+					Tag:            cfg.imageTag,
 					BuilderRef:     builderName,
 					ServiceAccount: serviceAccountName,
 					Source: v1alpha1.Source{


### PR DESCRIPTION
+ It is not an actual image but the tag the built images will be tagged with
+ It is common for the “tag” to refer to a fully-qualified tag
   aka `docker build -t reg.com/name`
+ Resolves #59, #40