### PR TITLE
Select the credentials based on the image

### DIFF
--- a/pkg/registry/image_factory.go
+++ b/pkg/registry/image_factory.go
@@ -14,7 +14,7 @@ type ImageFactory struct {
 }
 
 func (f *ImageFactory) NewRemote(imageRef ImageRef) (RemoteImage, error) {
-	remote, err := remote.NewImage(imageRef.Tag(), authn.DefaultKeychain, remote.FromBaseImage(imageRef.Tag()))
+	remote, err := remote.NewImage(imageRef.Tag(), f.KeychainFactory.KeychainForImageRef(imageRef), remote.FromBaseImage(imageRef.Tag()))
 	return remote, errors.Wrapf(err, "could not create remote image from ref %s", imageRef.Tag())
 }
 


### PR DESCRIPTION
Instead of using the default keychain we use our implementation
that looks through the secrets to find the correct secret
to use when retrieving the Image Metadata

Closes #83