### PR TITLE
Fix ServiceAccountName field on the Builder resource

### DIFF
--- a/pkg/apis/build/v1alpha2/builder_types.go
+++ b/pkg/apis/build/v1alpha2/builder_types.go
@@ -34,8 +34,8 @@ type BuilderSpec struct {
 
 // +k8s:openapi-gen=true
 type NamespacedBuilderSpec struct {
-	BuilderSpec    `json:",inline"`
-	ServiceAccount string `json:"serviceAccount,omitempty"`
+	BuilderSpec        `json:",inline"`
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 }
 
 // +k8s:openapi-gen=true

--- a/pkg/apis/build/v1alpha2/builder_validation.go
+++ b/pkg/apis/build/v1alpha2/builder_validation.go
@@ -11,8 +11,8 @@ import (
 )
 
 func (cb *Builder) SetDefaults(context.Context) {
-	if cb.Spec.ServiceAccount == "" {
-		cb.Spec.ServiceAccount = "default"
+	if cb.Spec.ServiceAccountName == "" {
+		cb.Spec.ServiceAccountName = "default"
 	}
 	if cb.Spec.Stack.Kind == "" {
 		cb.Spec.Stack.Kind = ClusterStackKind
@@ -34,7 +34,7 @@ func (s *BuilderSpec) Validate(ctx context.Context) *apis.FieldError {
 
 func (s *NamespacedBuilderSpec) Validate(ctx context.Context) *apis.FieldError {
 	return s.BuilderSpec.Validate(ctx).
-		Also(validate.FieldNotEmpty(s.ServiceAccount, "serviceAccount"))
+		Also(validate.FieldNotEmpty(s.ServiceAccountName, "serviceAccount"))
 }
 
 func validateStack(stack v1.ObjectReference) *apis.FieldError {

--- a/pkg/apis/build/v1alpha2/builder_validation_test.go
+++ b/pkg/apis/build/v1alpha2/builder_validation_test.go
@@ -34,7 +34,7 @@ func testBuilderValidation(t *testing.T, when spec.G, it spec.S) {
 				},
 				Order: nil, // No order validation
 			},
-			ServiceAccount: "some-service-account",
+			ServiceAccountName: "some-service-account",
 		},
 	}
 
@@ -47,9 +47,9 @@ func testBuilderValidation(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("defaults service account to default", func() {
-			builder.Spec.ServiceAccount = ""
+			builder.Spec.ServiceAccountName = ""
 			builder.SetDefaults(context.TODO())
-			assert.Equal(t, builder.Spec.ServiceAccount, "default")
+			assert.Equal(t, builder.Spec.ServiceAccountName, "default")
 		})
 
 		it("defaults stack.kind to ClusterStack", func() {

--- a/pkg/reconciler/builder/builder.go
+++ b/pkg/reconciler/builder/builder.go
@@ -128,7 +128,7 @@ func (c *Reconciler) reconcileBuilder(ctx context.Context, builder *buildapi.Bui
 	}
 
 	keychain, err := c.KeychainFactory.KeychainForSecretRef(ctx, registry.SecretRef{
-		ServiceAccount: builder.Spec.ServiceAccount,
+		ServiceAccount: builder.Spec.ServiceAccountName,
 		Namespace:      builder.Namespace,
 	})
 	if err != nil {

--- a/pkg/reconciler/builder/builder_test.go
+++ b/pkg/reconciler/builder/builder_test.go
@@ -123,12 +123,12 @@ func testBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 					},
 				},
 			},
-			ServiceAccount: "some-service-account",
+			ServiceAccountName: "some-service-account",
 		},
 	}
 
 	secretRef := registry.SecretRef{
-		ServiceAccount: builder.Spec.ServiceAccount,
+		ServiceAccount: builder.Spec.ServiceAccountName,
 		Namespace:      builder.Namespace,
 	}
 


### PR DESCRIPTION
- The serviceAccountName rename in v1alpha2 skipped the Builder resource

Fixes: https://github.com/pivotal/kpack/pull/861