### PR TITLE
Add support for signing Builders and ClusterBuilders

### DIFF
--- a/cmd/completion/main.go
+++ b/cmd/completion/main.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/sigstore/cosign/v2/pkg/oci/remote"
+
 	"github.com/BurntSushi/toml"
 	"github.com/buildpacks/lifecycle/platform/files"
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -154,7 +156,7 @@ func main() {
 
 func signImage(report files.Report, keychain authn.Keychain) error {
 	if hasCosign() {
-		cosignSigner := cosign.NewImageSigner(logger, sign.SignCmd)
+		cosignSigner := cosign.NewImageSigner(sign.SignCmd, remote.SignatureTag)
 
 		annotations, err := mapKeyValueArgs(cosignAnnotations)
 		if err != nil {

--- a/pkg/apis/build/v1alpha2/builder_lifecycle.go
+++ b/pkg/apis/build/v1alpha2/builder_lifecycle.go
@@ -16,6 +16,7 @@ type BuilderRecord struct {
 	ObservedStoreGeneration int64
 	ObservedStackGeneration int64
 	OS                      string
+	SignaturePaths          []CosignSignature
 }
 
 func (bs *BuilderStatus) BuilderRecord(record BuilderRecord) {
@@ -33,10 +34,11 @@ func (bs *BuilderStatus) BuilderRecord(record BuilderRecord) {
 	bs.ObservedStoreGeneration = record.ObservedStoreGeneration
 	bs.ObservedStackGeneration = record.ObservedStackGeneration
 	bs.OS = record.OS
+	bs.SignaturePaths = record.SignaturePaths
 }
 
-func (cb *BuilderStatus) ErrorCreate(err error) {
-	cb.Status = corev1alpha1.Status{
+func (bs *BuilderStatus) ErrorCreate(err error) {
+	bs.Status = corev1alpha1.Status{
 		Conditions: corev1alpha1.Conditions{
 			{
 				Type:               corev1alpha1.ConditionReady,

--- a/pkg/apis/build/v1alpha2/builder_types.go
+++ b/pkg/apis/build/v1alpha2/builder_types.go
@@ -56,6 +56,12 @@ type NamespacedBuilderSpec struct {
 }
 
 // +k8s:openapi-gen=true
+type CosignSignature struct {
+	SigningSecret string `json:"signingSecret"`
+	TargetDigest  string `json:"targetDigest"`
+}
+
+// +k8s:openapi-gen=true
 type BuilderStatus struct {
 	corev1alpha1.Status     `json:",inline"`
 	BuilderMetadata         corev1alpha1.BuildpackMetadataList `json:"builderMetadata,omitempty"`
@@ -65,6 +71,7 @@ type BuilderStatus struct {
 	ObservedStackGeneration int64                              `json:"observedStackGeneration,omitempty"`
 	ObservedStoreGeneration int64                              `json:"observedStoreGeneration,omitempty"`
 	OS                      string                             `json:"os,omitempty"`
+	SignaturePaths          []CosignSignature                  `json:"signaturePaths,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/cnb/create_builder_test.go
+++ b/pkg/cnb/create_builder_test.go
@@ -177,6 +177,12 @@ func testCreateBuilderOs(os string, t *testing.T, when spec.G, it spec.S) {
 			KpackVersion:      "v1.2.3 (git sha: abcdefg123456)",
 			KeychainFactory:   keychainFactory,
 			LifecycleProvider: lifecycleProvider,
+			ImageSigner: &fakeBuilderSigner{
+				signBuilder: func(ctx context.Context, s string, secrets []*corev1.Secret, keychain authn.Keychain) ([]buildapi.CosignSignature, error) {
+					// no-op
+					return nil, nil
+				},
+			},
 		}
 
 		addBuildpack = func(t *testing.T, id, version, homepage, api string, stacks []corev1alpha1.BuildpackStack) {
@@ -346,7 +352,7 @@ func testCreateBuilderOs(os string, t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("creates a custom builder", func() {
-			builderRecord, err := subject.CreateBuilder(ctx, builderKeychain, stackKeychain, fetcher, stack, clusterBuilderSpec)
+			builderRecord, err := subject.CreateBuilder(ctx, builderKeychain, stackKeychain, fetcher, stack, clusterBuilderSpec, []*corev1.Secret{})
 			require.NoError(t, err)
 
 			assert.Len(t, builderRecord.Buildpacks, 4)
@@ -636,11 +642,12 @@ func testCreateBuilderOs(os string, t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("creates images deterministically ", func() {
-			original, err := subject.CreateBuilder(ctx, builderKeychain, stackKeychain, fetcher, stack, clusterBuilderSpec)
+			original, err := subject.CreateBuilder(ctx, builderKeychain, stackKeychain, fetcher, stack, clusterBuilderSpec, []*corev1.Secret{})
 			require.NoError(t, err)
 
 			for i := 1; i <= 50; i++ {
-				other, err := subject.CreateBuilder(ctx, builderKeychain, stackKeychain, fetcher, stack, clusterBuilderSpec)
+				other, err := subject.CreateBuilder(ctx, builderKeychain, stackKeychain, fetcher, stack, clusterBuilderSpec, []*corev1.Secret{})
+
 				require.NoError(t, err)
 
 				require.Equal(t, original.Image, other.Image)
@@ -670,7 +677,7 @@ func testCreateBuilderOs(os string, t *testing.T, when spec.G, it spec.S) {
 					},
 				}
 
-				_, err := subject.CreateBuilder(ctx, builderKeychain, stackKeychain, fetcher, stack, clusterBuilderSpec)
+				_, err := subject.CreateBuilder(ctx, builderKeychain, stackKeychain, fetcher, stack, clusterBuilderSpec, []*corev1.Secret{})
 				require.EqualError(t, err, "validating buildpack io.buildpack.unsupported.stack@v4: stack io.buildpacks.stacks.some-stack is not supported")
 			})
 
@@ -694,7 +701,7 @@ func testCreateBuilderOs(os string, t *testing.T, when spec.G, it spec.S) {
 					}},
 				}}
 
-				_, err := subject.CreateBuilder(ctx, builderKeychain, stackKeychain, fetcher, stack, clusterBuilderSpec)
+				_, err := subject.CreateBuilder(ctx, builderKeychain, stackKeychain, fetcher, stack, clusterBuilderSpec, []*corev1.Secret{})
 				require.EqualError(t, err, "validating buildpack io.buildpack.unsupported.mixin@v4: stack missing mixin(s): something-missing-mixin, something-missing-mixin2")
 			})
 
@@ -739,7 +746,7 @@ func testCreateBuilderOs(os string, t *testing.T, when spec.G, it spec.S) {
 					}},
 				}}
 
-				_, err := subject.CreateBuilder(ctx, builderKeychain, stackKeychain, fetcher, stack, clusterBuilderSpec)
+				_, err := subject.CreateBuilder(ctx, builderKeychain, stackKeychain, fetcher, stack, clusterBuilderSpec, []*corev1.Secret{})
 				require.Nil(t, err)
 			})
 
@@ -764,7 +771,7 @@ func testCreateBuilderOs(os string, t *testing.T, when spec.G, it spec.S) {
 					}},
 				}}
 
-				_, err := subject.CreateBuilder(ctx, builderKeychain, nil, fetcher, stack, clusterBuilderSpec)
+				_, err := subject.CreateBuilder(ctx, builderKeychain, nil, fetcher, stack, clusterBuilderSpec, []*corev1.Secret{})
 				require.Error(t, err, "validating buildpack io.buildpack.relaxed.old.mixin@v4: stack missing mixin(s): build:common-mixin, run:common-mixin, another-common-mixin")
 			})
 
@@ -787,7 +794,7 @@ func testCreateBuilderOs(os string, t *testing.T, when spec.G, it spec.S) {
 					}},
 				}}
 
-				_, err := subject.CreateBuilder(ctx, builderKeychain, stackKeychain, fetcher, stack, clusterBuilderSpec)
+				_, err := subject.CreateBuilder(ctx, builderKeychain, stackKeychain, fetcher, stack, clusterBuilderSpec, []*corev1.Secret{})
 				require.EqualError(t, err, "validating buildpack io.buildpack.unsupported.buildpack.api@v4: unsupported buildpack api: 0.1, expecting: 0.2, 0.3")
 			})
 
@@ -830,7 +837,7 @@ func testCreateBuilderOs(os string, t *testing.T, when spec.G, it spec.S) {
 					}},
 				}}
 
-				_, err := subject.CreateBuilder(ctx, builderKeychain, stackKeychain, fetcher, stack, clusterBuilderSpec)
+				_, err := subject.CreateBuilder(ctx, builderKeychain, stackKeychain, fetcher, stack, clusterBuilderSpec, []*corev1.Secret{})
 				require.NoError(t, err)
 			})
 		})
@@ -857,11 +864,71 @@ func testCreateBuilderOs(os string, t *testing.T, when spec.G, it spec.S) {
 					},
 				}
 
-				_, err := subject.CreateBuilder(ctx, builderKeychain, stackKeychain, fetcher, stack, clusterBuilderSpec)
+				_, err := subject.CreateBuilder(ctx, builderKeychain, stackKeychain, fetcher, stack, clusterBuilderSpec, []*corev1.Secret{})
 				require.EqualError(t, err, "unsupported platform apis in kpack lifecycle: 0.1, 0.2, 0.999, expecting one of: 0.3, 0.4, 0.5, 0.6, 0.7, 0.8")
 			})
 		})
+
+		when("signing a builder image", func() {
+			it("does not populate the signature paths when no secrets were present", func() {
+				builderRecord, err := subject.CreateBuilder(ctx, builderKeychain, stackKeychain, fetcher, stack, clusterBuilderSpec, []*corev1.Secret{})
+				require.NoError(t, err)
+				require.NotNil(t, builderRecord)
+				require.Empty(t, builderRecord.SignaturePaths)
+			})
+
+			it("returns an error if signing fails", func() {
+				subject.ImageSigner = &fakeBuilderSigner{
+					signBuilder: func(ctx context.Context, s string, secrets []*corev1.Secret, keychain authn.Keychain) ([]buildapi.CosignSignature, error) {
+						return nil, fmt.Errorf("failed to sign builder")
+					},
+				}
+
+				fakeSecret := corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cosign-creds",
+						Namespace: "test-namespace",
+					},
+				}
+
+				_, err := subject.CreateBuilder(ctx, builderKeychain, stackKeychain, fetcher, stack, clusterBuilderSpec, []*corev1.Secret{&fakeSecret})
+				require.Error(t, err)
+			})
+
+			it("populates the signature paths when signing succeeds", func() {
+				fakeSecret := corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cosign-creds",
+						Namespace: "test-namespace",
+					},
+				}
+
+				subject.ImageSigner = &fakeBuilderSigner{
+					signBuilder: func(ctx context.Context, s string, secrets []*corev1.Secret, keychain authn.Keychain) ([]buildapi.CosignSignature, error) {
+						return []buildapi.CosignSignature{
+							{
+								SigningSecret: fmt.Sprintf("k8s://%s/%s", fakeSecret.Namespace, fakeSecret.Name),
+								TargetDigest:  "registry.local/test-image:signature-tag",
+							},
+						}, nil
+					},
+				}
+
+				builderRecord, err := subject.CreateBuilder(ctx, builderKeychain, stackKeychain, fetcher, stack, clusterBuilderSpec, []*corev1.Secret{&fakeSecret})
+				require.NoError(t, err)
+				require.NotNil(t, builderRecord)
+				require.NotEmpty(t, builderRecord.SignaturePaths)
+			})
+		})
 	})
+}
+
+type fakeBuilderSigner struct {
+	signBuilder func(context.Context, string, []*corev1.Secret, authn.Keychain) ([]buildapi.CosignSignature, error)
+}
+
+func (s *fakeBuilderSigner) SignBuilder(ctx context.Context, imageReference string, signingSecrets []*corev1.Secret, builderKeychain authn.Keychain) ([]buildapi.CosignSignature, error) {
+	return s.signBuilder(ctx, imageReference, signingSecrets, builderKeychain)
 }
 
 type fakeLifecycleProvider struct {

--- a/pkg/cosign/image_signer.go
+++ b/pkg/cosign/image_signer.go
@@ -1,37 +1,46 @@
 package cosign
 
 import (
+	"context"
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/buildpacks/lifecycle/platform/files"
+	"io/ioutil"
+
+	cosignutil "github.com/pivotal/kpack/pkg/cosign/util"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/pivotal/kpack/pkg/apis/build/v1alpha2"
 	"github.com/pkg/errors"
-	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
+	cosignoptions "github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
+	cosignremote "github.com/sigstore/cosign/v2/pkg/oci/remote"
+	corev1 "k8s.io/api/core/v1"
 )
 
-type SignFunc func(
-	ro *options.RootOptions, ko options.KeyOpts, signOpts options.SignOptions, imgs []string,
-) error
+type SignFunc func(*cosignoptions.RootOptions, cosignoptions.KeyOpts, cosignoptions.SignOptions, []string) error
 
-type ImageSigner struct {
-	Logger   *log.Logger
-	signFunc SignFunc
+type FetchSignatureFunc func(name.Reference, ...cosignremote.Option) (name.Tag, error)
+
+type BuilderSigner interface {
+	SignBuilder(context.Context, string, []*corev1.Secret, authn.Keychain) ([]v1alpha2.CosignSignature, error)
 }
 
-const (
-	cosignRepositoryEnv       = "COSIGN_REPOSITORY"
-	cosignDockerMediaTypesEnv = "COSIGN_DOCKER_MEDIA_TYPES"
-)
+type ImageSigner struct {
+	signFunc           SignFunc
+	fetchSignatureFunc FetchSignatureFunc
+}
 
-func NewImageSigner(logger *log.Logger, signFunc SignFunc) *ImageSigner {
+func NewImageSigner(signFunc SignFunc, fetchSignatureFunc FetchSignatureFunc) *ImageSigner {
 	return &ImageSigner{
-		Logger:   logger,
-		signFunc: signFunc,
+		signFunc:           signFunc,
+		fetchSignatureFunc: fetchSignatureFunc,
 	}
 }
 
-func (s *ImageSigner) Sign(ro *options.RootOptions, report files.Report, secretLocation string, annotations, cosignRepositories, cosignDockerMediaTypes map[string]interface{}) error {
+func (s *ImageSigner) Sign(ro *cosignoptions.RootOptions, report files.Report, secretLocation string, annotations, cosignRepositories, cosignDockerMediaTypes map[string]interface{}) error {
 	cosignSecrets, err := findCosignSecrets(secretLocation)
 	if err != nil {
 		return errors.Errorf("no keys found for cosign signing: %v\n", err)
@@ -60,12 +69,12 @@ func (s *ImageSigner) Sign(ro *options.RootOptions, report files.Report, secretL
 	return nil
 }
 
-func (s *ImageSigner) sign(ro *options.RootOptions, refImage, digest, secretLocation, cosignSecret string, annotations, cosignRepositories, cosignDockerMediaTypes map[string]interface{}) error {
+func (s *ImageSigner) sign(ro *cosignoptions.RootOptions, refImage, digest, secretLocation, cosignSecret string, annotations, cosignRepositories, cosignDockerMediaTypes map[string]interface{}) error {
 	cosignKeyFile := fmt.Sprintf("%s/%s/cosign.key", secretLocation, cosignSecret)
 	cosignPasswordFile := fmt.Sprintf("%s/%s/cosign.password", secretLocation, cosignSecret)
 
-	ko := options.KeyOpts{KeyRef: cosignKeyFile, PassFunc: func(bool) ([]byte, error) {
-		content, err := os.ReadFile(cosignPasswordFile)
+	ko := cosignoptions.KeyOpts{KeyRef: cosignKeyFile, PassFunc: func(bool) ([]byte, error) {
+		content, err := ioutil.ReadFile(cosignPasswordFile)
 		// When password file is not available, default empty password is used
 		if err != nil {
 			return []byte(""), nil
@@ -75,17 +84,17 @@ func (s *ImageSigner) sign(ro *options.RootOptions, refImage, digest, secretLoca
 	}}
 
 	if cosignRepository, ok := cosignRepositories[cosignSecret]; ok {
-		if err := os.Setenv(cosignRepositoryEnv, fmt.Sprintf("%s", cosignRepository)); err != nil {
-			return errors.Errorf("failed setting %s env variable: %v", cosignRepositoryEnv, err)
+		if err := os.Setenv(cosignutil.CosignRepositoryEnv, fmt.Sprintf("%s", cosignRepository)); err != nil {
+			return errors.Errorf("failed setting %s env variable: %v", cosignutil.CosignRepositoryEnv, err)
 		}
-		defer os.Unsetenv(cosignRepositoryEnv)
+		defer os.Unsetenv(cosignutil.CosignRepositoryEnv)
 	}
 
 	if cosignDockerMediaType, ok := cosignDockerMediaTypes[cosignSecret]; ok {
-		if err := os.Setenv(cosignDockerMediaTypesEnv, fmt.Sprintf("%s", cosignDockerMediaType)); err != nil {
+		if err := os.Setenv(cosignutil.CosignDockerMediaTypesEnv, fmt.Sprintf("%s", cosignDockerMediaType)); err != nil {
 			return errors.Errorf("failed setting COSIGN_DOCKER_MEDIA_TYPES env variable: %v", err)
 		}
-		defer os.Unsetenv(cosignDockerMediaTypesEnv)
+		defer os.Unsetenv(cosignutil.CosignDockerMediaTypesEnv)
 	}
 
 	var cosignAnnotations []string
@@ -93,9 +102,9 @@ func (s *ImageSigner) sign(ro *options.RootOptions, refImage, digest, secretLoca
 		cosignAnnotations = append(cosignAnnotations, fmt.Sprintf("%s=%s", key, value))
 	}
 
-	signOptions := options.SignOptions{
-		Registry: options.RegistryOptions{KubernetesKeychain: true},
-		AnnotationOptions: options.AnnotationOptions{
+	signOptions := cosignoptions.SignOptions{
+		Registry: cosignoptions.RegistryOptions{KubernetesKeychain: true},
+		AnnotationOptions: cosignoptions.AnnotationOptions{
 			Annotations: cosignAnnotations,
 		},
 		Upload:     true,
@@ -112,6 +121,127 @@ func (s *ImageSigner) sign(ro *options.RootOptions, refImage, digest, secretLoca
 	}
 
 	return nil
+}
+
+func (s *ImageSigner) SignBuilder(
+	ctx context.Context,
+	imageReference string,
+	serviceAccountSecrets []*corev1.Secret,
+	builderKeychain authn.Keychain,
+) ([]v1alpha2.CosignSignature, error) {
+	signaturePaths := make([]v1alpha2.CosignSignature, 0)
+	cosignSecrets := filterCosignSecrets(serviceAccountSecrets)
+
+	for _, cosignSecret := range cosignSecrets {
+		keyRef := fmt.Sprintf("k8s://%s/%s", cosignSecret.Namespace, cosignSecret.Name)
+		keyOpts := cosignoptions.KeyOpts{
+			KeyRef: keyRef,
+			PassFunc: func(bool) ([]byte, error) {
+				if password, ok := cosignSecret.Data[cosignutil.SecretDataCosignPassword]; ok {
+					return password, nil
+				}
+
+				return []byte(""), nil
+			},
+		}
+
+		if cosignRepository, ok := cosignSecret.Annotations[cosignutil.RepositoryAnnotationPrefix]; ok {
+			if err := os.Setenv(cosignutil.CosignRepositoryEnv, cosignRepository); err != nil {
+				return nil, fmt.Errorf("failed setting %s env variable: %w", cosignutil.CosignRepositoryEnv, err)
+			}
+		}
+
+		if cosignDockerMediaType, ok := cosignSecret.Annotations[cosignutil.DockerMediaTypesAnnotationPrefix]; ok {
+			if err := os.Setenv(cosignutil.CosignDockerMediaTypesEnv, cosignDockerMediaType); err != nil {
+				return nil, fmt.Errorf("failed setting %s env variable: %w", cosignutil.CosignDockerMediaTypesEnv, err)
+			}
+		}
+
+		registryOptions := cosignoptions.RegistryOptions{KubernetesKeychain: true, Keychain: builderKeychain}
+
+		signOptions := cosignoptions.SignOptions{
+			Registry:          registryOptions,
+			AnnotationOptions: cosignoptions.AnnotationOptions{},
+			Upload:            true,
+			Recursive:         false,
+			TlogUpload:        false,
+		}
+
+		rootOptions := cosignoptions.RootOptions{Timeout: cosignoptions.DefaultTimeout}
+
+		if err := s.signFunc(
+			&rootOptions,
+			keyOpts,
+			signOptions,
+			[]string{imageReference}); err != nil {
+			return nil, fmt.Errorf("unable to sign image with specified key from secret %s in namespace %s: %w", cosignSecret.Name, cosignSecret.Namespace, err)
+		}
+
+		reference, err := name.ParseReference(imageReference)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse reference: %w", err)
+		}
+
+		registryOpts, err := registryOptions.ClientOpts(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		signatureTag, err := s.fetchSignatureFunc(reference, registryOpts...)
+		if err != nil {
+			return nil, err
+		}
+
+		image, err := remote.Image(signatureTag, remote.WithAuthFromKeychain(builderKeychain))
+		if err != nil {
+			return nil, err
+		}
+
+		digest, err := image.Digest()
+		if err != nil {
+			return nil, err
+		}
+
+		signaturePaths = append(
+			signaturePaths,
+			v1alpha2.CosignSignature{
+				SigningSecret: keyRef,
+				TargetDigest:  signatureTag.Digest(digest.String()).String(),
+			},
+		)
+
+		if _, found := os.LookupEnv(cosignutil.CosignDockerMediaTypesEnv); found {
+			err = os.Unsetenv(cosignutil.CosignDockerMediaTypesEnv)
+			if err != nil {
+				return nil, fmt.Errorf("failed to cleanup environment variable %s: %w", cosignutil.CosignDockerMediaTypesEnv, err)
+			}
+		}
+
+		if _, found := os.LookupEnv(cosignutil.CosignRepositoryEnv); found {
+			err = os.Unsetenv(cosignutil.CosignRepositoryEnv)
+			if err != nil {
+				return nil, fmt.Errorf("failed to cleanup environment variable %s: %w", cosignutil.CosignRepositoryEnv, err)
+			}
+		}
+	}
+
+	return signaturePaths, nil
+}
+
+func filterCosignSecrets(serviceAccountSecrets []*corev1.Secret) []*corev1.Secret {
+	cosignSecrets := make([]*corev1.Secret, 0)
+
+	for _, cosignSecret := range serviceAccountSecrets {
+		_, passwordOk := cosignSecret.Data[cosignutil.SecretDataCosignPassword]
+		_, keyOk := cosignSecret.Data[cosignutil.SecretDataCosignKey]
+
+		if passwordOk && keyOk {
+			cosignSecrets = append(cosignSecrets, cosignSecret)
+		}
+	}
+
+	// successful
+	return cosignSecrets
 }
 
 func findCosignSecrets(secretLocation string) ([]string, error) {

--- a/pkg/cosign/testing/test_util.go
+++ b/pkg/cosign/testing/test_util.go
@@ -1,0 +1,60 @@
+package testing
+
+import (
+	"context"
+	"crypto"
+	"testing"
+
+	cosignutil "github.com/pivotal/kpack/pkg/cosign/util"
+
+	cosignVerify "github.com/sigstore/cosign/v2/cmd/cosign/cli/verify"
+	"github.com/sigstore/cosign/v2/pkg/cosign"
+	"github.com/sigstore/cosign/v2/pkg/signature"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func GenerateFakeKeyPair(t *testing.T, secretName string, secretNamespace string, password string, annotations map[string]string) corev1.Secret {
+	t.Helper()
+
+	passFunc := func(_ bool) ([]byte, error) {
+		return []byte(password), nil
+	}
+
+	keys, err := cosign.GenerateKeyPair(passFunc)
+	require.NoError(t, err)
+
+	data := map[string][]byte{
+		cosignutil.SecretDataCosignPublicKey: keys.PublicBytes,
+		cosignutil.SecretDataCosignKey:       keys.PrivateBytes,
+		cosignutil.SecretDataCosignPassword:  []byte(password),
+	}
+
+	secret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        secretName,
+			Namespace:   secretNamespace,
+			Annotations: annotations,
+		},
+		Data: data,
+	}
+
+	return secret
+}
+
+func Verify(t *testing.T, keyRef, imageRef string, annotations map[string]interface{}) error {
+	t.Helper()
+
+	cmd := cosignVerify.VerifyCommand{
+		KeyRef:        keyRef,
+		Annotations:   signature.AnnotationsMap{Annotations: annotations},
+		CheckClaims:   true,
+		HashAlgorithm: crypto.SHA256,
+		IgnoreTlog:    true,
+	}
+
+	args := []string{imageRef}
+
+	return cmd.Exec(context.Background(), args)
+}

--- a/pkg/cosign/util/constants.go
+++ b/pkg/cosign/util/constants.go
@@ -1,0 +1,12 @@
+package cosignutil
+
+const (
+	CosignRepositoryEnv       = "COSIGN_REPOSITORY"
+	CosignDockerMediaTypesEnv = "COSIGN_DOCKER_MEDIA_TYPES"
+
+	SecretDataCosignKey              = "cosign.key"
+	SecretDataCosignPassword         = "cosign.password"
+	SecretDataCosignPublicKey        = "cosign.pub"
+	DockerMediaTypesAnnotationPrefix = "kpack.io/cosign.docker-media-types"
+	RepositoryAnnotationPrefix       = "kpack.io/cosign.repository"
+)

--- a/pkg/reconciler/clusterbuilder/clusterbuilder_test.go
+++ b/pkg/reconciler/clusterbuilder/clusterbuilder_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/pivotal/kpack/pkg/secret/secretfakes"
+
 	"github.com/sclevine/spec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -41,9 +43,12 @@ func testClusterBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 	)
 
 	var (
-		builderCreator  = &testhelpers.FakeBuilderCreator{}
-		keychainFactory = &registryfakes.FakeKeychainFactory{}
-		fakeTracker     = &testhelpers.FakeTracker{}
+		builderCreator    = &testhelpers.FakeBuilderCreator{}
+		keychainFactory   = &registryfakes.FakeKeychainFactory{}
+		fakeTracker       = &testhelpers.FakeTracker{}
+		fakeSecretFetcher = &secretfakes.FakeFetchSecret{
+			FakeSecrets: []*corev1.Secret{},
+		}
 	)
 
 	rt := testhelpers.ReconcilerTester(t,
@@ -59,9 +64,29 @@ func testClusterBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 				ClusterStoreLister:     listers.GetClusterStoreLister(),
 				ClusterBuildpackLister: listers.GetClusterBuildpackLister(),
 				ClusterStackLister:     listers.GetClusterStackLister(),
+				SecretFetcher:          fakeSecretFetcher,
 			}
 			return &kreconciler.NetworkErrorReconciler{Reconciler: r}, rtesting.ActionRecorderList{fakeClient}, rtesting.EventList{Recorder: record.NewFakeRecorder(10)}
 		})
+
+	signingSecret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "some-secret-name",
+			Namespace: "some-sa-namespace",
+		},
+	}
+
+	serviceAccount := corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "some-sa-name",
+			Namespace: signingSecret.Namespace,
+		},
+		Secrets: []corev1.ObjectReference{
+			{
+				Name: signingSecret.Name,
+			},
+		},
+	}
 
 	clusterStore := &buildapi.ClusterStore{
 		ObjectMeta: metav1.ObjectMeta{
@@ -239,6 +264,8 @@ func testClusterBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 					clusterStore,
 					builder,
 					clusterBuildpack,
+					&signingSecret,
+					&serviceAccount,
 				},
 				WantErr: false,
 				WantStatusUpdates: []clientgotesting.UpdateActionImpl{
@@ -255,6 +282,7 @@ func testClusterBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 				Fetcher:         expectedFetcher,
 				ClusterStack:    clusterStack,
 				BuilderSpec:     builder.Spec.BuilderSpec,
+				SigningSecrets:  []*corev1.Secret{},
 			}}, builderCreator.CreateBuilderCalls)
 		})
 
@@ -297,6 +325,8 @@ func testClusterBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 					clusterStack,
 					clusterStore,
 					expectedBuilder,
+					&signingSecret,
+					&serviceAccount,
 				},
 				WantErr: false,
 			})
@@ -354,6 +384,8 @@ func testClusterBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 					clusterStack,
 					clusterStore,
 					builder,
+					&signingSecret,
+					&serviceAccount,
 				},
 				WantErr: false,
 			})
@@ -386,6 +418,8 @@ func testClusterBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 					clusterStack,
 					clusterStore,
 					builder,
+					&signingSecret,
+					&serviceAccount,
 				},
 				WantErr: true,
 				WantStatusUpdates: []clientgotesting.UpdateActionImpl{

--- a/pkg/reconciler/testhelpers/fake_builder_creator.go
+++ b/pkg/reconciler/testhelpers/fake_builder_creator.go
@@ -25,9 +25,10 @@ type CreateBuilderArgs struct {
 	Fetcher         cnb.RemoteBuildpackFetcher
 	ClusterStack    *buildapi.ClusterStack
 	BuilderSpec     buildapi.BuilderSpec
+	SigningSecrets  []*corev1.Secret
 }
 
-func (f *FakeBuilderCreator) CreateBuilder(ctx context.Context, builderKeychain authn.Keychain, stackKeychain authn.Keychain, fetcher cnb.RemoteBuildpackFetcher, clusterStack *buildapi.ClusterStack, spec buildapi.BuilderSpec) (buildapi.BuilderRecord, error) {
+func (f *FakeBuilderCreator) CreateBuilder(ctx context.Context, builderKeychain authn.Keychain, stackKeychain authn.Keychain, fetcher cnb.RemoteBuildpackFetcher, clusterStack *buildapi.ClusterStack, spec buildapi.BuilderSpec, signingSecrets []*corev1.Secret) (buildapi.BuilderRecord, error) {
 	f.CreateBuilderCalls = append(f.CreateBuilderCalls, CreateBuilderArgs{
 		Context:         ctx,
 		BuilderKeychain: builderKeychain,
@@ -35,6 +36,7 @@ func (f *FakeBuilderCreator) CreateBuilder(ctx context.Context, builderKeychain 
 		Fetcher:         fetcher,
 		ClusterStack:    clusterStack,
 		BuilderSpec:     spec,
+		SigningSecrets:  signingSecrets,
 	})
 
 	return f.Record, f.CreateErr

--- a/pkg/secret/secretfakes/fake_fetcher.go
+++ b/pkg/secret/secretfakes/fake_fetcher.go
@@ -1,0 +1,27 @@
+package secretfakes
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+type FakeFetchSecret struct {
+	FakeSecrets []*corev1.Secret
+	ShouldError bool
+	ErrorOut    error
+
+	SecretsForServiceAccountFunc func(context.Context, string, string) ([]*corev1.Secret, error)
+}
+
+func (f *FakeFetchSecret) SecretsForServiceAccount(ctx context.Context, serviceAccount, namespace string) ([]*corev1.Secret, error) {
+	if f.SecretsForServiceAccountFunc != nil {
+		return f.SecretsForServiceAccount(ctx, serviceAccount, namespace)
+	}
+
+	if f.ShouldError {
+		return nil, f.ErrorOut
+	}
+
+	return f.FakeSecrets, nil
+}

--- a/test/cosign_e2e_test.go
+++ b/test/cosign_e2e_test.go
@@ -1,0 +1,1123 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	cosigntesting "github.com/pivotal/kpack/pkg/cosign/testing"
+	cosignutil "github.com/pivotal/kpack/pkg/cosign/util"
+
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha2"
+	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
+	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func testSignBuilder(t *testing.T, _ spec.G, it spec.S) {
+	const (
+		testNamespace        = "test"
+		dockerSecret         = "docker-secret"
+		serviceAccountName   = "image-service-account"
+		clusterStoreName     = "store"
+		buildpackName        = "buildpack"
+		clusterBuildpackName = "cluster-buildpack"
+		clusterStackName     = "stack"
+		builderName          = "custom-signed-builder"
+		clusterBuilderName   = "custom-signed-cluster-builder"
+		cosignSecretName     = "cosign-creds"
+		secretRefFormat      = "k8s://%s/%s"
+	)
+
+	var (
+		cfg         config
+		clients     *clients
+		ctx         = context.Background()
+		builtImages map[string]struct{}
+	)
+
+	it.Before(func() {
+		cfg = loadConfig(t)
+		builtImages = map[string]struct{}{}
+
+		var err error
+		clients, err = newClients(t)
+		require.NoError(t, err)
+
+		err = clients.client.KpackV1alpha2().ClusterStores().Delete(ctx, clusterStoreName, metav1.DeleteOptions{})
+		if !errors.IsNotFound(err) {
+			require.NoError(t, err)
+		}
+
+		err = clients.client.KpackV1alpha2().Buildpacks(testNamespace).Delete(ctx, buildpackName, metav1.DeleteOptions{})
+		if !errors.IsNotFound(err) {
+			require.NoError(t, err)
+		}
+
+		err = clients.client.KpackV1alpha2().ClusterBuildpacks().Delete(ctx, clusterBuildpackName, metav1.DeleteOptions{})
+		if !errors.IsNotFound(err) {
+			require.NoError(t, err)
+		}
+
+		err = clients.client.KpackV1alpha2().ClusterStacks().Delete(ctx, clusterStackName, metav1.DeleteOptions{})
+		if !errors.IsNotFound(err) {
+			require.NoError(t, err)
+		}
+
+		err = clients.client.KpackV1alpha2().ClusterBuilders().Delete(ctx, clusterBuilderName, metav1.DeleteOptions{})
+		if !errors.IsNotFound(err) {
+			require.NoError(t, err)
+		}
+
+		deleteNamespace(t, ctx, clients, testNamespace)
+
+		_, err = clients.k8sClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   testNamespace,
+				Labels: readNamespaceLabelsFromEnv(),
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+	})
+
+	it.After(func() {
+		for tag := range builtImages {
+			deleteImageTag(t, tag)
+		}
+	})
+
+	it.Before(func() {
+		secret, err := cfg.makeRegistrySecret(dockerSecret, testNamespace)
+		require.NoError(t, err)
+
+		_, err = clients.k8sClient.CoreV1().Secrets(testNamespace).Create(ctx, secret, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		_, err = clients.k8sClient.CoreV1().ServiceAccounts(testNamespace).Create(ctx, &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: serviceAccountName,
+			},
+			Secrets: []corev1.ObjectReference{
+				{
+					Name: dockerSecret,
+				},
+			},
+			ImagePullSecrets: []corev1.LocalObjectReference{
+				{
+					Name: dockerSecret,
+				},
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		_, err = clients.client.KpackV1alpha2().ClusterStores().Create(ctx, &buildapi.ClusterStore{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: clusterStoreName,
+			},
+			Spec: buildapi.ClusterStoreSpec{
+				Sources: []corev1alpha1.ImageSource{
+					{Image: "gcr.io/paketo-buildpacks/bellsoft-liberica"},
+					{Image: "gcr.io/paketo-buildpacks/gradle"},
+					{Image: "gcr.io/paketo-buildpacks/syft"},
+					{Image: "gcr.io/paketo-buildpacks/executable-jar"},
+					{Image: "gcr.io/paketo-buildpacks/dist-zip"},
+					{Image: "gcr.io/paketo-buildpacks/spring-boot"},
+				},
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		_, err = clients.client.KpackV1alpha2().Buildpacks(testNamespace).Create(ctx, &buildapi.Buildpack{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: buildpackName,
+			},
+			Spec: buildapi.BuildpackSpec{
+				ImageSource: corev1alpha1.ImageSource{
+					Image: "gcr.io/paketo-buildpacks/bellsoft-liberica",
+				},
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		_, err = clients.client.KpackV1alpha2().ClusterBuildpacks().Create(ctx, &buildapi.ClusterBuildpack{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: clusterBuildpackName,
+			},
+			Spec: buildapi.ClusterBuildpackSpec{
+				ImageSource: corev1alpha1.ImageSource{
+					Image: "gcr.io/paketo-buildpacks/nodejs",
+				},
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		_, err = clients.client.KpackV1alpha2().ClusterStacks().Create(ctx, &buildapi.ClusterStack{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: clusterStackName,
+			},
+			Spec: buildapi.ClusterStackSpec{
+				Id: "io.buildpacks.stacks.bionic",
+				BuildImage: buildapi.ClusterStackSpecImage{
+					Image: "gcr.io/paketo-buildpacks/build:base-cnb",
+				},
+				RunImage: buildapi.ClusterStackSpecImage{
+					Image: "gcr.io/paketo-buildpacks/run:base-cnb",
+				},
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+	})
+
+	it("Signs a Builder image successfully when the key is not password-protected", func() {
+		cosignCredSecret := cosigntesting.GenerateFakeKeyPair(t, cosignSecretName, testNamespace, "", nil)
+		_, err := clients.k8sClient.CoreV1().Secrets(testNamespace).Create(ctx, &cosignCredSecret, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		serviceAccount, err := clients.k8sClient.CoreV1().ServiceAccounts(testNamespace).Get(ctx, serviceAccountName, metav1.GetOptions{})
+		require.NoError(t, err)
+
+		if serviceAccount.Secrets == nil {
+			serviceAccount.Secrets = make([]corev1.ObjectReference, 0)
+		}
+		serviceAccount.Secrets = append(serviceAccount.Secrets, corev1.ObjectReference{Name: cosignCredSecret.Name})
+
+		_, err = clients.k8sClient.CoreV1().ServiceAccounts(testNamespace).Update(ctx, serviceAccount, metav1.UpdateOptions{})
+		require.NoError(t, err)
+
+		builder, err := clients.client.KpackV1alpha2().Builders(testNamespace).Create(ctx, &buildapi.Builder{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      builderName,
+				Namespace: testNamespace,
+			},
+			Spec: buildapi.NamespacedBuilderSpec{
+				BuilderSpec: buildapi.BuilderSpec{
+					Tag: cfg.newImageTag(),
+					Stack: corev1.ObjectReference{
+						Name: clusterStackName,
+						Kind: "ClusterStack",
+					},
+					Store: corev1.ObjectReference{
+						Name: clusterStoreName,
+						Kind: "ClusterStore",
+					},
+					Order: []buildapi.BuilderOrderEntry{
+						{
+							Group: []buildapi.BuilderBuildpackRef{
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/nodejs",
+										},
+									},
+								},
+							},
+						},
+						{
+							Group: []buildapi.BuilderBuildpackRef{
+								{
+									ObjectReference: corev1.ObjectReference{
+										Name: buildpackName,
+										Kind: "Buildpack",
+									},
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/bellsoft-liberica",
+										},
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/gradle",
+										},
+										Optional: true,
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/syft",
+										},
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/executable-jar",
+										},
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/dist-zip",
+										},
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/spring-boot",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				ServiceAccountName: serviceAccountName,
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		waitUntilReady(t, ctx, clients, builder)
+
+		updatedBuilder, err := clients.client.KpackV1alpha2().Builders(testNamespace).Get(ctx, builderName, metav1.GetOptions{})
+		require.NoError(t, err)
+
+		assert.NotEmpty(t, updatedBuilder.Status.SignaturePaths)
+		assert.NotNil(t, updatedBuilder.Status.SignaturePaths[0])
+
+		err = cosigntesting.Verify(t, fmt.Sprintf(secretRefFormat, testNamespace, cosignSecretName), updatedBuilder.Status.LatestImage, nil)
+		require.NoError(t, err)
+	})
+
+	it("Signs a Builder image successfully when the key is password-protected", func() {
+		const CosignKeyPassword = "password"
+
+		cosignCredSecret := cosigntesting.GenerateFakeKeyPair(t, cosignSecretName, testNamespace, CosignKeyPassword, nil)
+		_, err := clients.k8sClient.CoreV1().Secrets(testNamespace).Create(ctx, &cosignCredSecret, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		serviceAccount, err := clients.k8sClient.CoreV1().ServiceAccounts(testNamespace).Get(ctx, serviceAccountName, metav1.GetOptions{})
+		require.NoError(t, err)
+
+		if serviceAccount.Secrets == nil {
+			serviceAccount.Secrets = make([]corev1.ObjectReference, 0)
+		}
+		serviceAccount.Secrets = append(serviceAccount.Secrets, corev1.ObjectReference{Name: cosignCredSecret.Name})
+
+		_, err = clients.k8sClient.CoreV1().ServiceAccounts(testNamespace).Update(ctx, serviceAccount, metav1.UpdateOptions{})
+		require.NoError(t, err)
+
+		builder, err := clients.client.KpackV1alpha2().Builders(testNamespace).Create(ctx, &buildapi.Builder{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      builderName,
+				Namespace: testNamespace,
+			},
+			Spec: buildapi.NamespacedBuilderSpec{
+				BuilderSpec: buildapi.BuilderSpec{
+					Tag: cfg.newImageTag(),
+					Stack: corev1.ObjectReference{
+						Name: clusterStackName,
+						Kind: "ClusterStack",
+					},
+					Store: corev1.ObjectReference{
+						Name: clusterStoreName,
+						Kind: "ClusterStore",
+					},
+					Order: []buildapi.BuilderOrderEntry{
+						{
+							Group: []buildapi.BuilderBuildpackRef{
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/nodejs",
+										},
+									},
+								},
+							},
+						},
+						{
+							Group: []buildapi.BuilderBuildpackRef{
+								{
+									ObjectReference: corev1.ObjectReference{
+										Name: buildpackName,
+										Kind: "Buildpack",
+									},
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/bellsoft-liberica",
+										},
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/gradle",
+										},
+										Optional: true,
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/syft",
+										},
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/executable-jar",
+										},
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/dist-zip",
+										},
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/spring-boot",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				ServiceAccountName: serviceAccountName,
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		waitUntilReady(t, ctx, clients, builder)
+
+		updatedBuilder, err := clients.client.KpackV1alpha2().Builders(testNamespace).Get(ctx, builderName, metav1.GetOptions{})
+		require.NoError(t, err)
+
+		assert.NotEmpty(t, updatedBuilder.Status.SignaturePaths)
+		assert.NotNil(t, updatedBuilder.Status.SignaturePaths[0])
+
+		err = cosigntesting.Verify(t, fmt.Sprintf(secretRefFormat, testNamespace, cosignSecretName), updatedBuilder.Status.LatestImage, nil)
+		require.NoError(t, err)
+	})
+
+	it("Generates more than one signature for a Builder image successfully when multiple secrets are present", func() {
+		const CosignKeyPassword = "password"
+		const cosignSecretName1 = "cosign-credentials-1"
+		const cosignSecretName2 = "cosign-credentials-2"
+
+		cosignCredSecret1 := cosigntesting.GenerateFakeKeyPair(t, cosignSecretName1, testNamespace, CosignKeyPassword, nil)
+		_, err := clients.k8sClient.CoreV1().Secrets(testNamespace).Create(ctx, &cosignCredSecret1, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		cosignCredSecret2 := cosigntesting.GenerateFakeKeyPair(t, cosignSecretName2, testNamespace, CosignKeyPassword, nil)
+		_, err = clients.k8sClient.CoreV1().Secrets(testNamespace).Create(ctx, &cosignCredSecret2, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		serviceAccount, err := clients.k8sClient.CoreV1().ServiceAccounts(testNamespace).Get(ctx, serviceAccountName, metav1.GetOptions{})
+		require.NoError(t, err)
+
+		if serviceAccount.Secrets == nil {
+			serviceAccount.Secrets = make([]corev1.ObjectReference, 0)
+		}
+		serviceAccount.Secrets = append(serviceAccount.Secrets,
+			corev1.ObjectReference{Name: cosignCredSecret1.Name},
+			corev1.ObjectReference{Name: cosignCredSecret2.Name})
+
+		_, err = clients.k8sClient.CoreV1().ServiceAccounts(testNamespace).Update(ctx, serviceAccount, metav1.UpdateOptions{})
+		require.NoError(t, err)
+
+		builder, err := clients.client.KpackV1alpha2().Builders(testNamespace).Create(ctx, &buildapi.Builder{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      builderName,
+				Namespace: testNamespace,
+			},
+			Spec: buildapi.NamespacedBuilderSpec{
+				BuilderSpec: buildapi.BuilderSpec{
+					Tag: cfg.newImageTag(),
+					Stack: corev1.ObjectReference{
+						Name: clusterStackName,
+						Kind: "ClusterStack",
+					},
+					Store: corev1.ObjectReference{
+						Name: clusterStoreName,
+						Kind: "ClusterStore",
+					},
+					Order: []buildapi.BuilderOrderEntry{
+						{
+							Group: []buildapi.BuilderBuildpackRef{
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/nodejs",
+										},
+									},
+								},
+							},
+						},
+						{
+							Group: []buildapi.BuilderBuildpackRef{
+								{
+									ObjectReference: corev1.ObjectReference{
+										Name: buildpackName,
+										Kind: "Buildpack",
+									},
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/bellsoft-liberica",
+										},
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/gradle",
+										},
+										Optional: true,
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/syft",
+										},
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/executable-jar",
+										},
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/dist-zip",
+										},
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/spring-boot",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				ServiceAccountName: serviceAccountName,
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		waitUntilReady(t, ctx, clients, builder)
+
+		updatedBuilder, err := clients.client.KpackV1alpha2().Builders(testNamespace).Get(ctx, builderName, metav1.GetOptions{})
+		require.NoError(t, err)
+
+		assert.NotEmpty(t, updatedBuilder.Status.SignaturePaths)
+		assert.Equal(t, 2, len(updatedBuilder.Status.SignaturePaths))
+		assert.NotNil(t, updatedBuilder.Status.SignaturePaths[0])
+		assert.NotNil(t, updatedBuilder.Status.SignaturePaths[1])
+
+		// tag is assigned to a single signature, but both are still verifiable
+		err = cosigntesting.Verify(t, fmt.Sprintf(secretRefFormat, testNamespace, cosignSecretName1), updatedBuilder.Status.LatestImage, nil)
+		require.NoError(t, err)
+
+		err = cosigntesting.Verify(t, fmt.Sprintf(secretRefFormat, testNamespace, cosignSecretName2), updatedBuilder.Status.LatestImage, nil)
+		require.NoError(t, err)
+	})
+
+	it("Saves a failure in the Builder record when signing fails", func() {
+		const CosignKeyPassword = "password"
+		const invalidPassword = "wrong-password"
+		const expectedErrorMessage = "unable to sign"
+
+		cosignCredSecret := cosigntesting.GenerateFakeKeyPair(t, cosignSecretName, testNamespace, CosignKeyPassword, nil)
+		cosignCredSecret.Data[cosignutil.SecretDataCosignPassword] = []byte(invalidPassword)
+
+		_, err := clients.k8sClient.CoreV1().Secrets(testNamespace).Create(ctx, &cosignCredSecret, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		serviceAccount, err := clients.k8sClient.CoreV1().ServiceAccounts(testNamespace).Get(ctx, serviceAccountName, metav1.GetOptions{})
+		require.NoError(t, err)
+
+		if serviceAccount.Secrets == nil {
+			serviceAccount.Secrets = make([]corev1.ObjectReference, 0)
+		}
+		serviceAccount.Secrets = append(serviceAccount.Secrets,
+			corev1.ObjectReference{Name: cosignCredSecret.Name})
+
+		_, err = clients.k8sClient.CoreV1().ServiceAccounts(testNamespace).Update(ctx, serviceAccount, metav1.UpdateOptions{})
+		require.NoError(t, err)
+
+		builder, err := clients.client.KpackV1alpha2().Builders(testNamespace).Create(ctx, &buildapi.Builder{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      builderName,
+				Namespace: testNamespace,
+			},
+			Spec: buildapi.NamespacedBuilderSpec{
+				BuilderSpec: buildapi.BuilderSpec{
+					Tag: cfg.newImageTag(),
+					Stack: corev1.ObjectReference{
+						Name: clusterStackName,
+						Kind: "ClusterStack",
+					},
+					Store: corev1.ObjectReference{
+						Name: clusterStoreName,
+						Kind: "ClusterStore",
+					},
+					Order: []buildapi.BuilderOrderEntry{
+						{
+							Group: []buildapi.BuilderBuildpackRef{
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/nodejs",
+										},
+									},
+								},
+							},
+						},
+						{
+							Group: []buildapi.BuilderBuildpackRef{
+								{
+									ObjectReference: corev1.ObjectReference{
+										Name: buildpackName,
+										Kind: "Buildpack",
+									},
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/bellsoft-liberica",
+										},
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/gradle",
+										},
+										Optional: true,
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/syft",
+										},
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/executable-jar",
+										},
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/dist-zip",
+										},
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/spring-boot",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				ServiceAccountName: serviceAccountName,
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		waitUntilFailed(t, ctx, clients, expectedErrorMessage, builder)
+
+		updatedBuilder, err := clients.client.KpackV1alpha2().Builders(testNamespace).Get(ctx, builderName, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, updatedBuilder.Status)
+
+		readyConditionBuilder := updatedBuilder.Status.GetCondition(corev1alpha1.ConditionReady)
+		require.False(t, readyConditionBuilder.IsTrue())
+		require.Contains(t, readyConditionBuilder.Message, expectedErrorMessage)
+	})
+
+	it("Signs a ClusterBuilder image successfully when the key is not password-protected", func() {
+		cosignCredSecret := cosigntesting.GenerateFakeKeyPair(t, cosignSecretName, testNamespace, "", nil)
+		_, err := clients.k8sClient.CoreV1().Secrets(testNamespace).Create(ctx, &cosignCredSecret, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		serviceAccount, err := clients.k8sClient.CoreV1().ServiceAccounts(testNamespace).Get(ctx, serviceAccountName, metav1.GetOptions{})
+		require.NoError(t, err)
+
+		if serviceAccount.Secrets == nil {
+			serviceAccount.Secrets = make([]corev1.ObjectReference, 0)
+		}
+		serviceAccount.Secrets = append(serviceAccount.Secrets, corev1.ObjectReference{Name: cosignCredSecret.Name})
+
+		_, err = clients.k8sClient.CoreV1().ServiceAccounts(testNamespace).Update(ctx, serviceAccount, metav1.UpdateOptions{})
+		require.NoError(t, err)
+
+		clusterBuilder, err := clients.client.KpackV1alpha2().ClusterBuilders().Create(ctx, &buildapi.ClusterBuilder{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: clusterBuilderName,
+			},
+			Spec: buildapi.ClusterBuilderSpec{
+				BuilderSpec: buildapi.BuilderSpec{
+					Tag: cfg.newImageTag(),
+					Stack: corev1.ObjectReference{
+						Name: clusterStackName,
+						Kind: "ClusterStack",
+					},
+					Store: corev1.ObjectReference{
+						Name: clusterStoreName,
+						Kind: "ClusterStore",
+					},
+					Order: []buildapi.BuilderOrderEntry{
+						{
+							Group: []buildapi.BuilderBuildpackRef{
+								{
+									ObjectReference: corev1.ObjectReference{
+										Name: clusterBuildpackName,
+										Kind: "ClusterBuildpack",
+									},
+								},
+							},
+						},
+						{
+							Group: []buildapi.BuilderBuildpackRef{
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/bellsoft-liberica",
+										},
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/gradle",
+										},
+										Optional: true,
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/syft",
+										},
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/executable-jar",
+										},
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/dist-zip",
+										},
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/spring-boot",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				ServiceAccountRef: corev1.ObjectReference{
+					Namespace: testNamespace,
+					Name:      serviceAccountName,
+				},
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		waitUntilReady(t, ctx, clients, clusterBuilder)
+
+		updatedBuilder, err := clients.client.KpackV1alpha2().ClusterBuilders().Get(ctx, clusterBuilderName, metav1.GetOptions{})
+		require.NoError(t, err)
+
+		assert.NotEmpty(t, updatedBuilder.Status.SignaturePaths)
+		assert.NotNil(t, updatedBuilder.Status.SignaturePaths[0])
+
+		err = cosigntesting.Verify(t, fmt.Sprintf(secretRefFormat, testNamespace, cosignSecretName), updatedBuilder.Status.LatestImage, nil)
+		require.NoError(t, err)
+	})
+
+	it("Signs a ClusterBuilder image successfully when the key is password-protected", func() {
+		const CosignKeyPassword = "password"
+
+		cosignCredSecret := cosigntesting.GenerateFakeKeyPair(t, cosignSecretName, testNamespace, CosignKeyPassword, nil)
+		_, err := clients.k8sClient.CoreV1().Secrets(testNamespace).Create(ctx, &cosignCredSecret, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		serviceAccount, err := clients.k8sClient.CoreV1().ServiceAccounts(testNamespace).Get(ctx, serviceAccountName, metav1.GetOptions{})
+		require.NoError(t, err)
+
+		if serviceAccount.Secrets == nil {
+			serviceAccount.Secrets = make([]corev1.ObjectReference, 0)
+		}
+		serviceAccount.Secrets = append(serviceAccount.Secrets, corev1.ObjectReference{Name: cosignCredSecret.Name})
+
+		_, err = clients.k8sClient.CoreV1().ServiceAccounts(testNamespace).Update(ctx, serviceAccount, metav1.UpdateOptions{})
+		require.NoError(t, err)
+
+		clusterBuilder, err := clients.client.KpackV1alpha2().ClusterBuilders().Create(ctx, &buildapi.ClusterBuilder{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: clusterBuilderName,
+			},
+			Spec: buildapi.ClusterBuilderSpec{
+				BuilderSpec: buildapi.BuilderSpec{
+					Tag: cfg.newImageTag(),
+					Stack: corev1.ObjectReference{
+						Name: clusterStackName,
+						Kind: "ClusterStack",
+					},
+					Store: corev1.ObjectReference{
+						Name: clusterStoreName,
+						Kind: "ClusterStore",
+					},
+					Order: []buildapi.BuilderOrderEntry{
+						{
+							Group: []buildapi.BuilderBuildpackRef{
+								{
+									ObjectReference: corev1.ObjectReference{
+										Name: clusterBuildpackName,
+										Kind: "ClusterBuildpack",
+									},
+								},
+							},
+						},
+						{
+							Group: []buildapi.BuilderBuildpackRef{
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/bellsoft-liberica",
+										},
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/gradle",
+										},
+										Optional: true,
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/syft",
+										},
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/executable-jar",
+										},
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/dist-zip",
+										},
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/spring-boot",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				ServiceAccountRef: corev1.ObjectReference{
+					Namespace: testNamespace,
+					Name:      serviceAccountName,
+				},
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		waitUntilReady(t, ctx, clients, clusterBuilder)
+
+		updatedBuilder, err := clients.client.KpackV1alpha2().ClusterBuilders().Get(ctx, clusterBuilderName, metav1.GetOptions{})
+		require.NoError(t, err)
+
+		assert.NotEmpty(t, updatedBuilder.Status.SignaturePaths)
+		assert.NotNil(t, updatedBuilder.Status.SignaturePaths[0])
+
+		err = cosigntesting.Verify(t, fmt.Sprintf(secretRefFormat, testNamespace, cosignSecretName), updatedBuilder.Status.LatestImage, nil)
+		require.NoError(t, err)
+	})
+
+	it("Generates more than one signature for a ClusterBuilder image successfully when multiple secrets are present", func() {
+		const cosignKeyPassword = "password"
+		const cosignSecretName1 = "cosign-credentials-1"
+		const cosignSecretName2 = "cosign-credentials-2"
+
+		cosignCredSecret1 := cosigntesting.GenerateFakeKeyPair(t, cosignSecretName1, testNamespace, cosignKeyPassword, nil)
+		_, err := clients.k8sClient.CoreV1().Secrets(testNamespace).Create(ctx, &cosignCredSecret1, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		cosignCredSecret2 := cosigntesting.GenerateFakeKeyPair(t, cosignSecretName2, testNamespace, cosignKeyPassword, nil)
+		_, err = clients.k8sClient.CoreV1().Secrets(testNamespace).Create(ctx, &cosignCredSecret2, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		serviceAccount, err := clients.k8sClient.CoreV1().ServiceAccounts(testNamespace).Get(ctx, serviceAccountName, metav1.GetOptions{})
+		require.NoError(t, err)
+
+		if serviceAccount.Secrets == nil {
+			serviceAccount.Secrets = make([]corev1.ObjectReference, 0)
+		}
+		serviceAccount.Secrets = append(
+			serviceAccount.Secrets,
+			corev1.ObjectReference{Name: cosignCredSecret1.Name},
+			corev1.ObjectReference{Name: cosignCredSecret2.Name})
+
+		_, err = clients.k8sClient.CoreV1().ServiceAccounts(testNamespace).Update(ctx, serviceAccount, metav1.UpdateOptions{})
+		require.NoError(t, err)
+
+		clusterBuilder, err := clients.client.KpackV1alpha2().ClusterBuilders().Create(ctx, &buildapi.ClusterBuilder{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: clusterBuilderName,
+			},
+			Spec: buildapi.ClusterBuilderSpec{
+				BuilderSpec: buildapi.BuilderSpec{
+					Tag: cfg.newImageTag(),
+					Stack: corev1.ObjectReference{
+						Name: clusterStackName,
+						Kind: "ClusterStack",
+					},
+					Store: corev1.ObjectReference{
+						Name: clusterStoreName,
+						Kind: "ClusterStore",
+					},
+					Order: []buildapi.BuilderOrderEntry{
+						{
+							Group: []buildapi.BuilderBuildpackRef{
+								{
+									ObjectReference: corev1.ObjectReference{
+										Name: clusterBuildpackName,
+										Kind: "ClusterBuildpack",
+									},
+								},
+							},
+						},
+						{
+							Group: []buildapi.BuilderBuildpackRef{
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/bellsoft-liberica",
+										},
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/gradle",
+										},
+										Optional: true,
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/syft",
+										},
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/executable-jar",
+										},
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/dist-zip",
+										},
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/spring-boot",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				ServiceAccountRef: corev1.ObjectReference{
+					Namespace: testNamespace,
+					Name:      serviceAccountName,
+				},
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		waitUntilReady(t, ctx, clients, clusterBuilder)
+
+		updatedBuilder, err := clients.client.KpackV1alpha2().ClusterBuilders().Get(ctx, clusterBuilderName, metav1.GetOptions{})
+		require.NoError(t, err)
+
+		assert.NotEmpty(t, updatedBuilder.Status.SignaturePaths)
+		assert.Equal(t, 2, len(updatedBuilder.Status.SignaturePaths))
+		assert.NotNil(t, updatedBuilder.Status.SignaturePaths[0])
+		assert.NotNil(t, updatedBuilder.Status.SignaturePaths[1])
+
+		err = cosigntesting.Verify(t, fmt.Sprintf(secretRefFormat, testNamespace, cosignSecretName1), updatedBuilder.Status.LatestImage, nil)
+		require.NoError(t, err)
+
+		err = cosigntesting.Verify(t, fmt.Sprintf(secretRefFormat, testNamespace, cosignSecretName2), updatedBuilder.Status.LatestImage, nil)
+		require.NoError(t, err)
+	})
+
+	it("Saves a failure in the ClusterBuilder record when signing fails", func() {
+		const cosignKeyPassword = "password"
+		const invalidPassword = "wrong-password"
+		const expectedErrorMessage = "unable to sign"
+
+		cosignCredSecret := cosigntesting.GenerateFakeKeyPair(t, cosignSecretName, testNamespace, cosignKeyPassword, nil)
+		cosignCredSecret.Data[cosignutil.SecretDataCosignPassword] = []byte(invalidPassword)
+
+		_, err = clients.k8sClient.CoreV1().Secrets(testNamespace).Create(ctx, &cosignCredSecret, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		serviceAccount, err := clients.k8sClient.CoreV1().ServiceAccounts(testNamespace).Get(ctx, serviceAccountName, metav1.GetOptions{})
+		require.NoError(t, err)
+
+		if serviceAccount.Secrets == nil {
+			serviceAccount.Secrets = make([]corev1.ObjectReference, 0)
+		}
+		serviceAccount.Secrets = append(
+			serviceAccount.Secrets,
+			corev1.ObjectReference{Name: cosignCredSecret.Name})
+
+		_, err = clients.k8sClient.CoreV1().ServiceAccounts(testNamespace).Update(ctx, serviceAccount, metav1.UpdateOptions{})
+		require.NoError(t, err)
+
+		clusterBuilder, err := clients.client.KpackV1alpha2().ClusterBuilders().Create(ctx, &buildapi.ClusterBuilder{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: clusterBuilderName,
+			},
+			Spec: buildapi.ClusterBuilderSpec{
+				BuilderSpec: buildapi.BuilderSpec{
+					Tag: cfg.newImageTag(),
+					Stack: corev1.ObjectReference{
+						Name: clusterStackName,
+						Kind: "ClusterStack",
+					},
+					Store: corev1.ObjectReference{
+						Name: clusterStoreName,
+						Kind: "ClusterStore",
+					},
+					Order: []buildapi.BuilderOrderEntry{
+						{
+							Group: []buildapi.BuilderBuildpackRef{
+								{
+									ObjectReference: corev1.ObjectReference{
+										Name: clusterBuildpackName,
+										Kind: "ClusterBuildpack",
+									},
+								},
+							},
+						},
+						{
+							Group: []buildapi.BuilderBuildpackRef{
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/bellsoft-liberica",
+										},
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/gradle",
+										},
+										Optional: true,
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/syft",
+										},
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/executable-jar",
+										},
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/dist-zip",
+										},
+									},
+								},
+								{
+									BuildpackRef: corev1alpha1.BuildpackRef{
+										BuildpackInfo: corev1alpha1.BuildpackInfo{
+											Id: "paketo-buildpacks/spring-boot",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				ServiceAccountRef: corev1.ObjectReference{
+					Namespace: testNamespace,
+					Name:      serviceAccountName,
+				},
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		waitUntilFailed(t, ctx, clients, expectedErrorMessage, clusterBuilder)
+
+		updatedBuilder, err := clients.client.KpackV1alpha2().ClusterBuilders().Get(ctx, clusterBuilderName, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, updatedBuilder.Status)
+
+		readyConditionBuilder := updatedBuilder.Status.GetCondition(corev1alpha1.ConditionReady)
+		require.False(t, readyConditionBuilder.IsTrue())
+		require.Contains(t, readyConditionBuilder.Message, expectedErrorMessage)
+	})
+}

--- a/test/execute_build_test.go
+++ b/test/execute_build_test.go
@@ -35,13 +35,14 @@ import (
 	"github.com/pivotal/kpack/pkg/registry"
 )
 
-func TestCreateImage(t *testing.T) {
+func TestKpackE2E(t *testing.T) {
 	rand.Seed(time.Now().Unix())
 
 	spec.Run(t, "CreateImage", testCreateImage)
+	spec.Run(t, "SignBuilder", testSignBuilder)
 }
 
-func testCreateImage(t *testing.T, when spec.G, it spec.S) {
+func testCreateImage(t *testing.T, _ spec.G, it spec.S) {
 	const (
 		testNamespace        = "test"
 		dockerSecret         = "docker-secret"
@@ -653,6 +654,26 @@ func waitUntilReady(t *testing.T, ctx context.Context, clients *clients, objects
 			require.NoError(t, err)
 
 			return kResource.Status.GetCondition(apis.ConditionReady).IsTrue()
+		}, 1*time.Second, 8*time.Minute)
+	}
+}
+
+func waitUntilFailed(t *testing.T, ctx context.Context, clients *clients, expectedMessage string, objects ...kmeta.OwnerRefable) {
+	for _, ob := range objects {
+		namespace := ob.GetObjectMeta().GetNamespace()
+		name := ob.GetObjectMeta().GetName()
+		gvr, _ := meta.UnsafeGuessKindToResource(ob.GetGroupVersionKind())
+
+		eventually(t, func() bool {
+			unstructured, err := clients.dynamicClient.Resource(gvr).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+			require.NoError(t, err)
+
+			kResource := &duckv1.KResource{}
+			err = duck.FromUnstructured(unstructured, kResource)
+			require.NoError(t, err)
+
+			condition := kResource.Status.GetCondition(apis.ConditionReady)
+			return condition.IsFalse() && "" != condition.Message && strings.Contains(condition.Message, expectedMessage)
 		}, 1*time.Second, 8*time.Minute)
 	}
 }


### PR DESCRIPTION
## Changes
* Implement Builder and ClusterBuilder signing with cosign, following the specification defined in [RFC 0007 - Integrate cosign with `kpack`](https://github.com/pivotal/kpack/blob/26d32c1a4e3995559c177f1deb5890f0a80c97e8/rfcs/0007-cosign-integration.md).

Fixes #942 