### PR TITLE
Fixing revision to build spring petclinic sample app

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -170,7 +170,7 @@ This tutorial will walk through creating a kpack [builder](builders.md) resource
       source:
         git:
           url: https://github.com/spring-projects/spring-petclinic
-          revision: 82cb521d636b282340378d80a6307a08e3d4a4c4
+          revision: 3be289517d320a47bb8f359acc1d1daf0829ed0b
     ```
 
    - Replace `<DOCKER-IMAGE-TAG>` with a valid image tag that exists in the registry you configured with the `--docker-server` flag when creating a Secret in step #1. Something like: your-name/app or gcr.io/your-project/app


### PR DESCRIPTION
I was working on publishing an image built by kpack for Jesse, see [this thread](https://cloud-native.slack.com/archives/C0333LG7C9J/p1689091406019899) for context and I noticed the revision declared un our tutorial was failing with the following error:

```
   [INFO] BUILD FAILURE
      [INFO] ------------------------------------------------------------------------
      [INFO] Total time:  17:41 min
      [INFO] Finished at: 2023-07-12T19:36:25Z
      [INFO] ------------------------------------------------------------------------
      [ERROR] Failed to execute goal ro.isdc.wro4j:wro4j-maven-plugin:1.8.0:run (default) on project spring-petclinic: Execution default of goal ro.isdc.wro4j:wro4j-maven-plugin:1.8.0:run failed: Plugin ro.isdc.wro4j:wro4j-maven-plugin:1.8.0 or one of its dependencies could not be resolved: The following artifacts could not be resolved: net.bytebuddy:byte-buddy:jar:1.9.10, net.bytebuddy:byte-buddy-agent:jar:1.9.10, ro.isdc.wro4j:wro4j-core:jar:1.8.0, org.apache.commons:commons-lang3:jar:3.4, com.google.javascript:closure-compiler:jar:v20160315, com.google.javascript:closure-compiler-externs:jar:v20160315, args4j:args4j:jar:2.0.26, com.google.protobuf:protobuf-java:jar:2.5.0, com.google.code.findbugs:jsr305:jar:1.3.9, com.github.lltyk:dojo-shrinksafe:jar:1.7.2, org.jruby:jruby-core:jar:9.0.5.0, com.github.jnr:jnr-netdb:jar:1.1.5, com.github.jnr:jnr-enxio:jar:0.10, com.github.jnr:jnr-x86asm:jar:1.0.2, com.github.jnr:jnr-unixsocket:jar:0.10, com.github.jnr:jnr-posix:jar:3.0.27, com.github.jnr:jnr-constants:jar:0.9.0, com.github.jnr:jffi:jar:1.2.10, com.github.jnr:jffi:jar:native:1.2.10, org.jruby.joni:joni:jar:2.1.9, org.jruby.extras:bytelist:jar:1.0.13, org.jruby.jcodings:jcodings:jar:1.0.17, org.jruby:dirgra:jar:0.3, com.headius:invokebinder:jar:1.7, com.headius:options:jar:1.4, com.jcraft:jzlib:jar:1.1.3, com.martiansoftware:nailgun-server:jar:0.9.1, joda-time:joda-time:jar:2.8.2, org.jruby:jruby-stdlib:jar:9.0.5.0, com.darrinholst:sass-java-gems:jar:3.4.20.0, nz.co.edmi:bourbon-gem-jar:jar:2.1.0, me.n4u.sass:sass-gems:jar:3.1.19, com.github.sommeri:less4j:jar:1.17.2, org.antlr:antlr-runtime:jar:3.5.2, commons-beanutils:commons-beanutils:jar:1.8.3, org.codehaus.gmaven.runtime:gmaven-runtime-1.7:jar:1.3, org.codehaus.gmaven.feature:gmaven-feature-support:jar:1.3, org.codehaus.gmaven.feature:gmaven-feature-api:jar:1.3, org.codehaus.gmaven.runtime:gmaven-runtime-support:jar:1.3, org.codehaus.gmaven.runtime:gmaven-runtime-api:jar:1.3, org.sonatype.gshell:gshell-io:jar:2.0, com.thoughtworks.qdox:qdox:jar:1.10, org.codehaus.groovy:groovy-all:jar:1.7.4, org.apache.ant:ant:jar:1.8.2, org.apache.ant:ant-launcher:jar:1.8.2, jline:jline:jar:0.9.94, org.webjars:webjars-locator:jar:0.30, org.webjars:webjars-locator-core:jar:0.30, org.apache.commons:commons-compress:jar:1.9, com.fasterxml.jackson.core:jackson-databind:jar:2.3.3, com.fasterxml.jackson.core:jackson-annotations:jar:2.3.0, com.fasterxml.jackson.core:jackson-core:jar:2.3.3, org.webjars:jshint:jar:2.6.3-2, org.webjars:less:jar:1.3.3, org.webjars:emberjs:jar:1.9.0-1, org.webjars:handlebars:jar:3.0.3, org.webjars:coffee-script:jar:1.10.0, org.webjars:envjs:jar:1.2, org.webjars:jslint:jar:20140708-394bf29, org.webjars:json2:jar:20110223, javax.servlet:servlet-api:jar:2.3, org.apache.maven:maven-plugin-api:jar:3.0.4, org.apache.maven:maven-model:jar:3.0.4, org.sonatype.sisu:sisu-inject-plexus:jar:2.3.0, org.sonatype.sisu:sisu-inject-bean:jar:2.3.0, org.sonatype.sisu:sisu-guice:jar:no_aop:3.1.0, org.sonatype.sisu:sisu-guava:jar:0.9.9, org.apache.maven:maven-artifact:jar:3.0.4, org.codehaus.plexus:plexus-utils:jar:2.0.6, org.apache.maven:maven-core:jar:3.0.4, org.apache.maven:maven-settings:jar:3.0.4, org.apache.maven:maven-settings-builder:jar:3.0.4, org.apache.maven:maven-repository-metadata:jar:3.0.4, org.apache.maven:maven-model-builder:jar:3.0.4, org.apache.maven:maven-aether-provider:jar:3.0.4, org.sonatype.aether:aether-spi:jar:1.13.1, org.sonatype.aether:aether-impl:jar:1.13.1, org.sonatype.aether:aether-api:jar:1.13.1, org.sonatype.aether:aether-util:jar:1.13.1, org.codehaus.plexus:plexus-classworlds:jar:2.4, org.slf4j:slf4j-log4j12:jar:1.7.16, log4j:log4j:jar:1.2.17, org.slf4j:slf4j-api:jar:1.7.16: Could not transfer artifact net.bytebuddy:byte-buddy:jar:1.9.10 from/to spring-snapshots (https://repo.spring.io/snapshot): repo.spring.io: Unknown host repo.spring.io -> [Help 1]
      [ERROR]
      [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
      [ERROR] Re-run Maven using the -X switch to enable full debug logging.
      [ERROR]
      [ERROR] For more information about the errors and possible solutions, please read the following articles:
      [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginResolutionException
unable to invoke layer creator
unable to contribute application layer
error running build
exit status 1
```

I just updated to the latest commit in the spring petclinic sample and I was able to build the image. This PR is just for updating that value