### PR TITLE
Update release process to use tags and version branches

### DIFF
--- a/.github/actions/pack-build/action.yml
+++ b/.github/actions/pack-build/action.yml
@@ -41,7 +41,7 @@ runs:
     if: ${{ runner.os == 'linux' }}
     shell: bash
     run: |
-      [[ $GITHUB_REF =~ ^refs\/heads\/release\/(.*)$ ]] && version=${BASH_REMATCH[1]} || version=0.0.0
+      [[ $GITHUB_REF =~ ^refs\/tags\/v(.*)$ ]] && version=${BASH_REMATCH[1]} || version=0.0.0
 
       KPACK_VERSION=$version
       KPACK_COMMIT=$GITHUB_SHA
@@ -65,7 +65,7 @@ runs:
     if: ${{ runner.os == 'windows' }}
     shell: bash
     run: |
-      [[ $GITHUB_REF =~ ^refs\/heads\/release\/(.*)$ ]] && version=${BASH_REMATCH[1]} || version=0.0.0
+      [[ $GITHUB_REF =~ ^refs\/tags\/v(.*)$ ]] && version=${BASH_REMATCH[1]} || version=0.0.0
 
       KPACK_VERSION=$version
       KPACK_COMMIT=$GITHUB_SHA

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,9 +5,8 @@ on:
     branches:
     - main
     - release/**
-  pull_request:
-    branches:
-    - release/**
+    tags:
+    - v[0-9]+.[0-9]+.[0-9]+-?**
 
 defaults:
   run:
@@ -428,7 +427,7 @@ jobs:
       - build-init-windows-image
       - completion-windows-image
       - lifecycle-image
-    if: ${{ startsWith(github.ref, 'refs/heads/release/') }}
+    if: ${{ startsWith(github.ref, 'refs/tag/v') }}
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -458,10 +457,10 @@ jobs:
         username: ${{ secrets.REGISTRY_USER }}
         password: ${{ secrets.REGISTRY_PASSWORD }}
 
-    - name: Parse branch name
+    - name: Parse tag name
       run: |
         echo "GITHUB_REF=${GITHUB_REF}"
-        [[ $GITHUB_REF =~ ^refs\/heads\/release\/(.*)$ ]] && version=${BASH_REMATCH[1]}
+        [[ $GITHUB_REF =~ ^refs\/tags\/v(.*)$ ]] && version=${BASH_REMATCH[1]} 
         if [[ -z "${version}" ]]; then
           echo "ERROR: kpack version not detected."
           exit 1

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,45 +1,46 @@
 # Release Process
 
-Kpack release process is composed of 3 phases:
-- [Development](#development)
-- [Feature Complete](#feature-complete)
-- [Release Finalization](#release-finalization)
+Kpack release process:
+- [Releasing a new Major/Minor Version](#releasing-a-new-majorminor-version)
+- [Releasing a new Patch Version](#releasing-a-new-patch-version)
+- [Release Automation](#release-automation)
 
-## Phases
 
-### Development
+## Releasing a new Major/Minor Version
 
-Our development flow is detailed in [Development](DEVELOPMENT.md).
-
-### Feature Complete
-
-During this period, a **Release Candidate** (RC) is published and used for further User Acceptance testing (`UAT`). Furthermore, additional RCs may be published based on assessment by the `kpack` maintainers of the **impact**, **effort** and **risk** of including the changes in the upcoming release. Any other changes may be merged into the `main` branch through the normal process, and will make it into the next release.
-
-To produce the release candidate a maintainer will:
-- Create a new release branch in form `release/<MAYOR-VERSION>.<MINOR-VERSION>.<PATCH-VERSION>-rc.<NUMBER>` yielding a draft GitHub release to be published.
+To produce a major/minor release from `main` a maintainer will:
+- Create a new release branch in form `release/<MAJOR-VERSION>.<MINOR-VERSION>.x` from the `main` branch
+- Tag release branch as `v<MAYOR-VERSION>.<MINOR-VERSION>.<PATCH-VERSION>` or `v<MAYOR-VERSION>.<MINOR-VERSION>.<PATCH-VERSION>-rc.<NUMBER>` for RC versions
+- GitHub Actions will generate a draft GitHub release.
 - Publish the [GitHub release][release]:
-    - Tag release branch as `v<MAYOR-VERSION>.<MINOR-VERSION>.<PATCH-VERSION>-rc.<NUMBER>`.
-    - Release should be marked as "pre-release".
+    - For RCs, the release should be marked as "pre-release"
+      >NOTE: A **Release Candidate** (RC) is published and used for further User Acceptance testing (`UAT`). Furthermore, additional RCs may be published based on assessment by the `kpack` maintainers of the **impact**, **effort** and **risk** of including the changes in the upcoming release. Any other changes may be merged into the `main` branch through the normal process, and will make it into the next release.
     - The GitHub release will contain the following:
         - **artifacts**
         - **release notes**
+        - **asset checksums**
     - The release notes should be edited and cleaned
 
-### Release Finalization
+## Releasing a new Patch Version
 
-The maintainer will:
-- Create a new release branch in form `release/<MAYOR-VERSION>.<MINOR-VERSION>.<PATCH-VERSION>` yielding a draft GitHub release to be published.
-- Publish the [GitHub release][release] while tagging the release branch as `v<VERSION>`.
-    - Tag release branch as `v<MAYOR-VERSION>.<MINOR-VERSION>.<PATCH-VERSION>`.
+>Patches may be released for backwards-compatible bug fixes and/or dependency bumps to resolve vulnerabilities. There is no patch guarantees for anything other than the latest minor version.
+
+To produce a patch release from an existing `release` branch a maintainer will:
+- PR changes into the release branch corresponding to the minor that will be patched.
+- Tag release branch as `v<MAYOR-VERSION>.<MINOR-VERSION>.<PATCH-VERSION>` or `v<MAYOR-VERSION>.<MINOR-VERSION>.<PATCH-VERSION>-rc.<NUMBER>` for RC versions
+- GitHub Actions will generate a draft GitHub release.
+- Publish the [GitHub release][release]:
+    - For RCs, the release should be marked as "pre-release"
+      >NOTE: A **Release Candidate** (RC) is published and used for further User Acceptance testing (`UAT`). Furthermore, additional RCs may be published based on assessment by the `kpack` maintainers of the **impact**, **effort** and **risk** of including the changes in the upcoming release. Any other changes may be merged into the `main` branch through the normal process, and will make it into the next release.
     - The GitHub release will contain the following:
         - **artifacts**
         - **release notes**
-
-And with that, you're done!
+        - **asset checksums**
+    - The release notes should be edited and cleaned
 
 ## Release automation
 
-- The release candidate process is automated using [GitHub Actions][github-release]. The workflow is triggered by a push to a release branch.
+- The release candidate process is automated using [GitHub Actions][github-release]. The workflow is triggered by a pushed version tag.
 - The release finalization is manual step
 
 [release]: https://github.com/pivotal/kpack/releases


### PR DESCRIPTION
- This is more convenient than a branch per release
- Also, update corresponding release documentation