### PR TITLE
[0.10.x] Enable building images that require libgit2 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,6 +54,8 @@ jobs:
         pack_version: ${{ env.PACK_VERSION }}
         tag: ${{ env.PUBLIC_IMAGE_DEV_REPO }}/controller
         bp_go_targets: "./cmd/controller"
+        builder: gcr.io/cf-build-service-public/ci/kpack-builder
+        additional_pack_args: '--env BP_GIT2GO_ENABLED="true" --env BP_GIT2GO_USE_LIBSSL="true"'
 
   webhook-image:
     runs-on: ubuntu-latest
@@ -108,6 +110,8 @@ jobs:
         pack_version: ${{ env.PACK_VERSION }}
         tag: ${{ env.PUBLIC_IMAGE_DEV_REPO }}/build-init
         bp_go_targets: "./cmd/build-init"
+        builder: gcr.io/cf-build-service-public/ci/kpack-builder
+        additional_pack_args: '--env BP_GIT2GO_ENABLED="true" --env BP_GIT2GO_USE_LIBSSL="true"'
 
   build-waiter-image:
     runs-on: ubuntu-latest
@@ -163,7 +167,7 @@ jobs:
         tag: ${{ env.PUBLIC_IMAGE_DEV_REPO }}/build-init-windows
         bp_go_targets: '.\cmd\build-init;.\cmd\network-wait-launcher'
         builder: gcr.io/cf-build-service-public/kpack-windows-builder
-        additional_pack_args: "--trust-builder"
+        additional_pack_args: '--trust-builder --env BP_MSYS2_COPY_FILES=c:\layers\samples_msys2\msys2\msys64\mingw64\bin\libgit2.dll;c:\layers\samples_msys2\msys2\msys64\mingw64\bin\zlib1.dll;c:\layers\samples_msys2\msys2\msys64\mingw64\bin\libssl-1_1-x64.dll;c:\layers\samples_msys2\msys2\msys64\mingw64\bin\libssh2-1.dll;c:\layers\samples_msys2\msys2\msys64\mingw64\bin\libcrypto-1_1-x64.dll;c:\layers\samples_msys2\msys2\msys64\mingw64\bin\libhttp_parser-2.dll'
 
   completion-windows-image:
     runs-on: windows-2019


### PR DESCRIPTION
- This has been removed in the latest versions of kpack but is required for older versions