### PR TITLE
[0.10.x] more ci related backports

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -194,12 +194,20 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+    - name: Docker Login
+      uses: docker/login-action@v2.2.0
+      with:
+        registry: ${{ secrets.REGISTRY_HOST }}
+        username: ${{ secrets.REGISTRY_USER }}
+        password: ${{ secrets.REGISTRY_PASSWORD }}
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod'
     - name: Build
       run: |
+        trap 'echo -e "$output"' EXIT
+
         output=$(go run ./hack/lifecycle/main.go --tag=${{ env.PUBLIC_IMAGE_DEV_REPO }}/lifecycle 2>&1)
         image=$(echo "$output" | grep "saved lifecycle" | awk -F  "saved lifecycle image: " '{print $2}')
         mkdir images

--- a/test/config.go
+++ b/test/config.go
@@ -20,8 +20,6 @@ type config struct {
 	testRegistryUsername string
 	testRegistryPassword string
 	imageTag             string
-
-	generatedImageNames []string
 }
 
 type dockerCredentials map[string]authn.AuthConfig
@@ -56,7 +54,6 @@ func loadConfig(t *testing.T) config {
 
 func (c *config) newImageTag() string {
 	genTag := c.imageTag + "-" + strconv.Itoa(rand.Int())
-	c.generatedImageNames = append(c.generatedImageNames, genTag)
 	return genTag
 }
 


### PR DESCRIPTION
🚂🍒 The cherry picking train never stops! 🚂🍒
 
Cherry pick/backport of:
- b34ba9487679ad111717ee6f9c27311a605e338d is required because the local registry used in GHA has weird delete rules
- 12387f881ff0ee2d520290e96f1e542c3cb37252 to log into docker in order to push the lifecycle image


Test run showing e2e passed: https://github.com/buildpacks-community/kpack/actions/runs/5660918441