### PR TITLE
[0.8.x] Revert test commit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,6 @@ on:
     branches:
     - main
     - release/**
-    - 0.8.x-ci-cherrypicks
     tags:
     - v[0-9]+.[0-9]+.[0-9]+-?**
 


### PR DESCRIPTION
c83542f377bc5a13ffafa950c821623609984fe2 was a test commit to trigger the workflow and wasn't supposed to be in the actual PR