### PR TITLE
[0.7.x] more ci related backports

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -113,24 +113,6 @@ jobs:
         builder: gcr.io/cf-build-service-public/ci/kpack-builder
         additional_pack_args: '--env BP_GIT2GO_ENABLED="true" --env BP_GIT2GO_USE_LIBSSL="true"'
 
-  build-waiter-image:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Docker Login
-      uses: docker/login-action@v2.2.0
-      with:
-        registry: ${{ secrets.REGISTRY_HOST }}
-        username: ${{ secrets.REGISTRY_USER }}
-        password: ${{ secrets.REGISTRY_PASSWORD }}
-    - name: Build
-      uses: ./.github/actions/pack-build
-      with:
-        pack_version: ${{ env.PACK_VERSION }}
-        tag: ${{ env.PUBLIC_IMAGE_DEV_REPO }}/build-waiter
-        bp_go_targets: "./cmd/build-waiter"
-
   rebase-image:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -194,12 +194,20 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+    - name: Docker Login
+      uses: docker/login-action@v2.2.0
+      with:
+        registry: ${{ secrets.REGISTRY_HOST }}
+        username: ${{ secrets.REGISTRY_USER }}
+        password: ${{ secrets.REGISTRY_PASSWORD }}
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod'
     - name: Build
       run: |
+        trap 'echo -e "$output"' EXIT
+
         output=$(go run ./hack/lifecycle/main.go --tag=${{ env.PUBLIC_IMAGE_DEV_REPO }}/lifecycle 2>&1)
         image=$(echo "$output" | grep "saved lifecycle" | awk -F  "saved lifecycle image: " '{print $2}')
         mkdir images

--- a/test/config.go
+++ b/test/config.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"strconv"
 	"testing"
+
+	"github.com/google/go-containerregistry/pkg/authn"
 )
 
 type config struct {
@@ -28,4 +30,10 @@ func loadConfig(t *testing.T) config {
 func (c *config) newImageTag() string {
 	genTag := c.imageTag + "-" + strconv.Itoa(rand.Int())
 	return genTag
+}
+
+type dockerCredentials map[string]authn.AuthConfig
+
+type dockerConfigJson struct {
+	Auths dockerCredentials `json:"auths"`
 }

--- a/test/config.go
+++ b/test/config.go
@@ -11,8 +11,6 @@ type config struct {
 	builder      string
 	testRegistry string
 	imageTag     string
-
-	generatedImageNames []string
 }
 
 func loadConfig(t *testing.T) config {
@@ -29,6 +27,5 @@ func loadConfig(t *testing.T) config {
 
 func (c *config) newImageTag() string {
 	genTag := c.imageTag + "-" + strconv.Itoa(rand.Int())
-	c.generatedImageNames = append(c.generatedImageNames, genTag)
 	return genTag
 }

--- a/test/execute_build_test.go
+++ b/test/execute_build_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/sclevine/spec"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -53,13 +52,15 @@ func testCreateImage(t *testing.T, when spec.G, it spec.S) {
 	)
 
 	var (
-		cfg     config
-		clients *clients
-		ctx     = context.Background()
+		cfg         config
+		clients     *clients
+		ctx         = context.Background()
+		builtImages map[string]struct{}
 	)
 
 	it.Before(func() {
 		cfg = loadConfig(t)
+		builtImages = map[string]struct{}{}
 
 		var err error
 		clients, err = newClients(t)
@@ -92,7 +93,7 @@ func testCreateImage(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	it.After(func() {
-		for _, tag := range cfg.generatedImageNames {
+		for tag := range builtImages {
 			deleteImageTag(t, tag)
 		}
 	})
@@ -384,7 +385,7 @@ func testCreateImage(t *testing.T, when spec.G, it spec.S) {
 					}, metav1.CreateOptions{})
 					require.NoError(t, err)
 
-					validateImageCreate(t, clients, image, expectedResources)
+					builtImages[validateImageCreate(t, clients, image, expectedResources)] = struct{}{}
 					validateRebase(t, ctx, clients, image.Name, testNamespace)
 				})
 			}
@@ -400,7 +401,7 @@ func testCreateImage(t *testing.T, when spec.G, it spec.S) {
 			},
 		}
 
-		generateRebuild(&ctx, t, cfg, clients, volumeCacheConfig, testNamespace, clusterBuilderName, serviceAccountName)
+		builtImages[generateRebuild(&ctx, t, cfg, clients, volumeCacheConfig, testNamespace, clusterBuilderName, serviceAccountName)] = struct{}{}
 	})
 
 	it("can trigger rebuilds with registry cache", func() {
@@ -411,11 +412,11 @@ func testCreateImage(t *testing.T, when spec.G, it spec.S) {
 				Tag: cacheImageTag,
 			},
 		}
-		generateRebuild(&ctx, t, cfg, clients, registryCacheConfig, testNamespace, clusterBuilderName, serviceAccountName)
+		builtImages[generateRebuild(&ctx, t, cfg, clients, registryCacheConfig, testNamespace, clusterBuilderName, serviceAccountName)] = struct{}{}
 	})
 }
 
-func generateRebuild(ctx *context.Context, t *testing.T, cfg config, clients *clients, cacheConfig *buildapi.ImageCacheConfig, testNamespace, clusterBuilderName, serviceAccountName string) {
+func generateRebuild(ctx *context.Context, t *testing.T, cfg config, clients *clients, cacheConfig *buildapi.ImageCacheConfig, testNamespace, clusterBuilderName, serviceAccountName string) string {
 	expectedResources := corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{
 			corev1.ResourceMemory: resource.MustParse("1G"),
@@ -455,7 +456,7 @@ func generateRebuild(ctx *context.Context, t *testing.T, cfg config, clients *cl
 	}, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	validateImageCreate(t, clients, image, expectedResources)
+	originalImageTag := validateImageCreate(t, clients, image, expectedResources)
 
 	list, err := clients.client.KpackV1alpha2().Builds(testNamespace).List(*ctx, metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("image.kpack.io/image=%s", imageName),
@@ -475,6 +476,11 @@ func generateRebuild(ctx *context.Context, t *testing.T, cfg config, clients *cl
 		require.NoError(t, err)
 		return len(list.Items) == 2
 	}, 5*time.Second, 1*time.Minute)
+
+	rebuiltImageTag := validateImageCreate(t, clients, image, expectedResources)
+	require.Equal(t, originalImageTag, rebuiltImageTag)
+
+	return originalImageTag
 }
 
 func readNamespaceLabelsFromEnv() map[string]string {
@@ -514,13 +520,13 @@ func waitUntilReady(t *testing.T, ctx context.Context, clients *clients, objects
 	}
 }
 
-func validateImageCreate(t *testing.T, clients *clients, image *buildapi.Image, expectedResources corev1.ResourceRequirements) {
+func validateImageCreate(t *testing.T, clients *clients, image *buildapi.Image, expectedResources corev1.ResourceRequirements) string {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	logTail := &bytes.Buffer{}
 	go func() {
-		err := logs.NewBuildLogsClient(clients.k8sClient).Tail(ctx, logTail, image.Name, "1", image.Namespace)
+		err := logs.NewBuildLogsClient(clients.k8sClient).TailImage(ctx, logTail, image.Name, image.Namespace)
 		require.NoError(t, err)
 	}()
 
@@ -528,23 +534,26 @@ func validateImageCreate(t *testing.T, clients *clients, image *buildapi.Image, 
 	waitUntilReady(t, ctx, clients, image)
 
 	registryClient := &registry.Client{}
-	_, _, err = registryClient.Fetch(authn.DefaultKeychain, image.Spec.Tag)
+	_, identifier, err := registryClient.Fetch(authn.DefaultKeychain, image.Spec.Tag)
 	require.NoError(t, err)
 
 	eventually(t, func() bool {
 		return strings.Contains(logTail.String(), "Build successful")
 	}, 1*time.Second, 10*time.Second)
 
+	buildList, err := clients.client.KpackV1alpha2().Builds(image.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("image.kpack.io/image=%s", image.Name),
+	})
+	require.NoError(t, err)
+
 	podList, err := clients.k8sClient.CoreV1().Pods(image.Namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("image.kpack.io/image=%s", image.Name),
 	})
 	require.NoError(t, err)
 
-	require.Len(t, podList.Items, 1)
-	pod := podList.Items[0]
+	require.Len(t, podList.Items, len(buildList.Items))
 
-	require.Equal(t, 1, len(pod.Spec.Containers))
-	assert.Equal(t, expectedResources, pod.Spec.Containers[0].Resources)
+	return identifier
 }
 
 func validateRebase(t *testing.T, ctx context.Context, clients *clients, imageName, testNamespace string) {
@@ -585,13 +594,22 @@ func validateRebase(t *testing.T, ctx context.Context, clients *clients, imageNa
 
 func deleteImageTag(t *testing.T, deleteImageTag string) {
 	reference, err := name.ParseReference(deleteImageTag, name.WeakValidation)
-	require.NoError(t, err)
+	if err != nil {
+		t.Logf("error cleaning up: could not parse reference: %s", err)
+		return
+	}
 
 	authenticator, err := authn.DefaultKeychain.Resolve(reference.Context().Registry)
-	require.NoError(t, err)
+	if err != nil {
+		t.Logf("error cleaning up: could not resolve keychain to delete tag: %s", err)
+		return
+	}
 
 	err = remote.Delete(reference, remote.WithAuth(authenticator))
-	require.NoError(t, err)
+	if err != nil {
+		t.Logf("error cleaning up: could not delete reference: %s", err)
+		return
+	}
 }
 
 func deleteNamespace(t *testing.T, ctx context.Context, clients *clients, namespace string) {


### PR DESCRIPTION
Similar to #1289, but with an additional commits to:
- stop building the build-waiter image
- fix the secrets that are used in the e2e tests

Test run: https://github.com/buildpacks-community/kpack/actions/runs/5671406232