### PR TITLE
[Issue-1266] Changes image signing before metadata retrieval 

### DIFF
--- a/pkg/cosign/image_signer.go
+++ b/pkg/cosign/image_signer.go
@@ -2,7 +2,6 @@ package cosign
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -62,7 +61,7 @@ func (s *ImageSigner) sign(ro *options.RootOptions, refImage, secretLocation, co
 	cosignPasswordFile := fmt.Sprintf("%s/%s/cosign.password", secretLocation, cosignSecret)
 
 	ko := options.KeyOpts{KeyRef: cosignKeyFile, PassFunc: func(bool) ([]byte, error) {
-		content, err := ioutil.ReadFile(cosignPasswordFile)
+		content, err := os.ReadFile(cosignPasswordFile)
 		// When password file is not available, default empty password is used
 		if err != nil {
 			return []byte(""), nil
@@ -114,7 +113,7 @@ func (s *ImageSigner) sign(ro *options.RootOptions, refImage, secretLocation, co
 func findCosignSecrets(secretLocation string) ([]string, error) {
 	var result []string
 
-	files, err := ioutil.ReadDir(secretLocation)
+	files, err := os.ReadDir(secretLocation)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cosign/image_signer_test.go
+++ b/pkg/cosign/image_signer_test.go
@@ -112,11 +112,11 @@ func testImageSigner(t *testing.T, when spec.G, it spec.S) {
 
 					var passwordFileContent []byte
 					if secretKey1 == ko.KeyRef {
-						passwordFileContent, _ = ioutil.ReadFile(passwordFile1)
+						passwordFileContent, _ = os.ReadFile(passwordFile1)
 						password1Count++
 						assert.Equal(t, []byte(""), passwordFileContent)
 					} else {
-						passwordFileContent, _ = ioutil.ReadFile(passwordFile2)
+						passwordFileContent, _ = os.ReadFile(passwordFile2)
 						password2Count++
 						assert.NotEqual(t, []byte(""), passwordFileContent)
 					}

--- a/pkg/notary/image_signer.go
+++ b/pkg/notary/image_signer.go
@@ -2,9 +2,9 @@ package notary
 
 import (
 	"encoding/hex"
-	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -126,7 +126,7 @@ func (s *ImageSigner) makeGUNAndTargets(report platform.ExportReport, keychain a
 func (s *ImageSigner) makeCryptoService(notarySecretDir string) (*cryptoservice.CryptoService, error) {
 	cryptoStore := storage.NewMemoryStore(nil)
 
-	fileInfos, err := ioutil.ReadDir(notarySecretDir)
+	fileInfos, err := os.ReadDir(notarySecretDir)
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +134,7 @@ func (s *ImageSigner) makeCryptoService(notarySecretDir string) (*cryptoservice.
 	privateKeyFound := false
 	for _, info := range fileInfos {
 		if strings.HasSuffix(info.Name(), ".key") {
-			buf, err := ioutil.ReadFile(filepath.Join(notarySecretDir, info.Name()))
+			buf, err := os.ReadFile(filepath.Join(notarySecretDir, info.Name()))
 			if err != nil {
 				return nil, err
 			}
@@ -160,7 +160,7 @@ func (s *ImageSigner) makeCryptoService(notarySecretDir string) (*cryptoservice.
 
 func k8sSecretPassRetriever(notarySecretDir string) func(_, _ string, _ bool, _ int) (passphrase string, giveup bool, err error) {
 	return func(_, _ string, _ bool, _ int) (passphrase string, giveup bool, err error) {
-		buf, err := ioutil.ReadFile(filepath.Join(notarySecretDir, "password"))
+		buf, err := os.ReadFile(filepath.Join(notarySecretDir, "password"))
 		return strings.TrimSpace(string(buf)), false, err
 	}
 }


### PR DESCRIPTION
supports image building with registries that have policy that does not allow unsigned image pulling