### PR TITLE
[0.12.x] Fix azure devops

### DIFF
--- a/pkg/git/fetch.go
+++ b/pkg/git/fetch.go
@@ -9,6 +9,7 @@ import (
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/protocol/packp/capability"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/pkg/errors"
 )
@@ -16,6 +17,13 @@ import (
 type Fetcher struct {
 	Logger   *log.Logger
 	Keychain GitKeychain
+}
+
+func init() {
+	//remove multi_ack and multi_ack_detailed from unsupported capabilities to enable Azure DevOps git support
+	transport.UnsupportedCapabilities = []capability.Capability{
+		capability.ThinPack,
+	}
 }
 
 func (f Fetcher) Fetch(dir, gitURL, gitRevision, metadataDir string) error {


### PR DESCRIPTION
- remove multi_ack and multi_ack_detailed from unsupported capabilities
- see https://github.com/go-git/go-git/blob/52c2972976737a00fce91d7deb1278a6a460cae6/_examples/azure_devops/main.go\#L21-L36 for more info
- we should be able to remove this once go-git implements full support for v2 git with multi_ack