### PR TITLE
Pinning to a specific commit in fetch test

### DIFF
--- a/pkg/git/fetch_test.go
+++ b/pkg/git/fetch_test.go
@@ -90,7 +90,7 @@ func testGitCheckout(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("preserves executable permission", func() {
-			err := fetcher.Fetch(testDir, "https://github.com/pivotal/kpack", "main", metadataDir)
+			err := fetcher.Fetch(testDir, "https://github.com/pivotal/kpack", "b8c0d491135595cc00ab78f6214bef8a7a20afd8", metadataDir)
 			require.NoError(t, err)
 
 			fileInfo, err := os.Lstat(path.Join(testDir, "hack", "local.sh"))


### PR DESCRIPTION
- A change to the filename broke the test on multiple branches. Pinning this to prevent this from happening again