### PR TITLE
Add Builder UpToDate Condition

### DIFF
--- a/config/builder.yaml
+++ b/config/builder.yaml
@@ -37,6 +37,9 @@ spec:
     - name: Ready
       type: string
       jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: UpToDate
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"UpToDate\")].status"
   conversion:
     strategy: Webhook
     webhook:

--- a/config/clusterbuilder.yaml
+++ b/config/clusterbuilder.yaml
@@ -37,6 +37,9 @@ spec:
     - name: Ready
       type: string
       jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: UpToDate
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"UpToDate\")].status"
   names:
     kind: ClusterBuilder
     listKind: ClusterBuilderList

--- a/docs/builders.md
+++ b/docs/builders.md
@@ -161,3 +161,13 @@ version) in the following order:
    `paketo-buildpacks/gradle` is a sub-buildpack of `paketo-buildpacks/java`)
 1. As a sub-buildpack of any ClusterBuildpacks
 1. As a sub-buildpack in the ClusterStore specified in the Builder spec.
+
+### <a id='status'></a>Builder Status Conditions
+
+Builders and ClusterBuilders have two Conditions that represent the overall status of the Builder.
+
+The 'Ready' condition is used to show that the Builder is able to be used in Builds
+
+The 'UpToDate' condition indicates whether the most recent reconcile of the Builder 
+was successful. When this condition is false, that means that the Builder may not have the 
+latest Stack or Buildpacks due to ongoing reconcile failures.

--- a/pkg/apis/build/v1alpha2/builder_resource.go
+++ b/pkg/apis/build/v1alpha2/builder_resource.go
@@ -7,6 +7,7 @@ type BuilderResource interface {
 	GetNamespace() string
 	BuildBuilderSpec() corev1alpha1.BuildBuilderSpec
 	Ready() bool
+	UpToDate() bool
 	BuildpackMetadata() corev1alpha1.BuildpackMetadataList
 	RunImage() string
 	GetKind() string

--- a/pkg/apis/build/v1alpha2/builder_types.go
+++ b/pkg/apis/build/v1alpha2/builder_types.go
@@ -10,8 +10,12 @@ import (
 )
 
 const (
-	BuilderKind   = "Builder"
-	BuilderCRName = "builders.kpack.io"
+	BuilderKind                                      = "Builder"
+	BuilderCRName                                    = "builders.kpack.io"
+	ConditionUpToDate     corev1alpha1.ConditionType = "UpToDate"
+	NoLatestImageReason   string                     = "NoLatestImage"
+	NoLatestImageMessage  string                     = "Builder has no latestImage"
+	ReconcileFailedReason string                     = "ReconcileFailed"
 )
 
 // +genclient

--- a/pkg/apis/build/v1alpha2/image_builds_test.go
+++ b/pkg/apis/build/v1alpha2/image_builds_test.go
@@ -372,6 +372,7 @@ func testImageBuilds(t *testing.T, when spec.G, it spec.S) {
 
 type TestBuilderResource struct {
 	BuilderReady     bool
+	BuilderUpToDate  bool
 	BuilderMetadata  []corev1alpha1.BuildpackMetadata
 	ImagePullSecrets []corev1.LocalObjectReference
 	Kind             string
@@ -394,6 +395,10 @@ func (t TestBuilderResource) BuildBuilderSpec() corev1alpha1.BuildBuilderSpec {
 
 func (t TestBuilderResource) Ready() bool {
 	return t.BuilderReady
+}
+
+func (t TestBuilderResource) UpToDate() bool {
+	return t.BuilderUpToDate
 }
 
 func (t TestBuilderResource) BuildpackMetadata() corev1alpha1.BuildpackMetadataList {

--- a/pkg/apis/build/v1alpha2/image_lifecycle.go
+++ b/pkg/apis/build/v1alpha2/image_lifecycle.go
@@ -10,9 +10,11 @@ import (
 )
 
 const (
-	BuilderNotFound = "BuilderNotFound"
-	BuilderNotReady = "BuilderNotReady"
-	BuilderReady    = "BuilderReady"
+	BuilderNotFound    = "BuilderNotFound"
+	BuilderNotReady    = "BuilderNotReady"
+	BuilderReady       = "BuilderReady"
+	BuilderNotUpToDate = "BuilderNotUpToDate"
+	BuilderUpToDate    = "BuilderUpToDate"
 )
 
 func (im *Image) BuilderNotFound() corev1alpha1.Conditions {

--- a/pkg/apis/build/v1alpha2/image_types.go
+++ b/pkg/apis/build/v1alpha2/image_types.go
@@ -136,3 +136,4 @@ func (i *Image) NamespacedName() types.NamespacedName {
 }
 
 const ConditionBuilderReady corev1alpha1.ConditionType = "BuilderReady"
+const ConditionBuilderUpToDate corev1alpha1.ConditionType = "BuilderUpToDate"

--- a/pkg/duckbuilder/duck_builder.go
+++ b/pkg/duckbuilder/duck_builder.go
@@ -37,6 +37,11 @@ func (b *DuckBuilder) Ready() bool {
 		(b.Generation == b.Status.ObservedGeneration)
 }
 
+func (b *DuckBuilder) UpToDate() bool {
+ 	return b.Status.GetCondition(buildapi.ConditionUpToDate).IsTrue() &&
+ 		(b.Generation == b.Status.ObservedGeneration)
+}
+
 func (b *DuckBuilder) BuildBuilderSpec() corev1alpha1.BuildBuilderSpec {
 	return corev1alpha1.BuildBuilderSpec{
 		Image:            b.Status.LatestImage,

--- a/pkg/reconciler/builder/builder_test.go
+++ b/pkg/reconciler/builder/builder_test.go
@@ -245,6 +245,10 @@ func testBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 								Type:   corev1alpha1.ConditionReady,
 								Status: corev1.ConditionTrue,
 							},
+							{
+								Type:   buildapi.ConditionUpToDate,
+								Status: corev1.ConditionTrue,
+							},
 						},
 					},
 					BuilderMetadata: []corev1alpha1.BuildpackMetadata{
@@ -320,6 +324,10 @@ func testBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 								Type:   corev1alpha1.ConditionReady,
 								Status: corev1.ConditionTrue,
 							},
+							{
+								Type:   buildapi.ConditionUpToDate,
+								Status: corev1.ConditionTrue,
+							},
 						},
 					},
 					BuilderMetadata: []corev1alpha1.BuildpackMetadata{},
@@ -383,6 +391,10 @@ func testBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 							Type:   corev1alpha1.ConditionReady,
 							Status: corev1.ConditionTrue,
 						},
+						{
+							Type:   buildapi.ConditionUpToDate,
+							Status: corev1.ConditionTrue,
+						},
 					},
 				},
 				BuilderMetadata: []corev1alpha1.BuildpackMetadata{
@@ -436,6 +448,13 @@ func testBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 										{
 											Type:    corev1alpha1.ConditionReady,
 											Status:  corev1.ConditionFalse,
+											Reason:  buildapi.NoLatestImageReason,
+											Message: buildapi.NoLatestImageMessage,
+										},
+										{
+											Type:    buildapi.ConditionUpToDate,
+											Status:  corev1.ConditionFalse,
+											Reason:  buildapi.ReconcileFailedReason,
 											Message: "create error",
 										},
 									},
@@ -491,6 +510,13 @@ func testBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 										{
 											Type:    corev1alpha1.ConditionReady,
 											Status:  corev1.ConditionFalse,
+											Reason:  buildapi.NoLatestImageReason,
+											Message: buildapi.NoLatestImageMessage,
+										},
+										{
+											Type:    buildapi.ConditionUpToDate,
+											Status:  corev1.ConditionFalse,
+											Reason:  buildapi.ReconcileFailedReason,
 											Message: "Error: clusterstack 'some-stack' is not ready",
 										},
 									},
@@ -526,6 +552,13 @@ func testBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 										{
 											Type:    corev1alpha1.ConditionReady,
 											Status:  corev1.ConditionFalse,
+											Reason:  buildapi.NoLatestImageReason,
+											Message: buildapi.NoLatestImageMessage,
+										},
+										{
+											Type:    buildapi.ConditionUpToDate,
+											Status:  corev1.ConditionFalse,
+											Reason:  buildapi.ReconcileFailedReason,
 											Message: `clusterstore.kpack.io "some-store" not found`,
 										},
 									},
@@ -561,6 +594,13 @@ func testBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 										{
 											Type:    corev1alpha1.ConditionReady,
 											Status:  corev1.ConditionFalse,
+											Reason:  buildapi.NoLatestImageReason,
+											Message: buildapi.NoLatestImageMessage,
+										},
+										{
+											Type:    buildapi.ConditionUpToDate,
+											Status:  corev1.ConditionFalse,
+											Reason:  buildapi.ReconcileFailedReason,
 											Message: `clusterstack.kpack.io "some-stack" not found`,
 										},
 									},

--- a/pkg/reconciler/clusterbuilder/clusterbuilder_test.go
+++ b/pkg/reconciler/clusterbuilder/clusterbuilder_test.go
@@ -136,7 +136,6 @@ func testClusterBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 			APIVersion: "kpack.io/v1alpha2",
 		},
 	}
-
 	builder := &buildapi.ClusterBuilder{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       builderName,
@@ -233,6 +232,10 @@ func testClusterBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 								Type:   corev1alpha1.ConditionReady,
 								Status: corev1.ConditionTrue,
 							},
+							{
+								Type:   buildapi.ConditionUpToDate,
+								Status: corev1.ConditionTrue,
+							},
 						},
 					},
 					BuilderMetadata: []corev1alpha1.BuildpackMetadata{
@@ -308,6 +311,10 @@ func testClusterBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 								Type:   corev1alpha1.ConditionReady,
 								Status: corev1.ConditionTrue,
 							},
+							{
+								Type:   buildapi.ConditionUpToDate,
+								Status: corev1.ConditionTrue,
+							},
 						},
 					},
 					BuilderMetadata: []corev1alpha1.BuildpackMetadata{},
@@ -363,6 +370,10 @@ func testClusterBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 							Type:   corev1alpha1.ConditionReady,
 							Status: corev1.ConditionTrue,
 						},
+						{
+							Type:   buildapi.ConditionUpToDate,
+							Status: corev1.ConditionTrue,
+						},
 					},
 				},
 				BuilderMetadata: []corev1alpha1.BuildpackMetadata{
@@ -405,7 +416,14 @@ func testClusterBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 							{
 								Type:    corev1alpha1.ConditionReady,
 								Status:  corev1.ConditionFalse,
+								Message: buildapi.NoLatestImageMessage,
+								Reason:  buildapi.NoLatestImageReason,
+							},
+							{
+								Type:    buildapi.ConditionUpToDate,
+								Status:  corev1.ConditionFalse,
 								Message: "create error",
+								Reason:  buildapi.ReconcileFailedReason,
 							},
 						},
 					},
@@ -472,7 +490,14 @@ func testClusterBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 										{
 											Type:    corev1alpha1.ConditionReady,
 											Status:  corev1.ConditionFalse,
+											Message: buildapi.NoLatestImageMessage,
+											Reason:  buildapi.NoLatestImageReason,
+										},
+										{
+											Type:    buildapi.ConditionUpToDate,
+											Status:  corev1.ConditionFalse,
 											Message: "stack some-stack is not ready",
+											Reason:  buildapi.ReconcileFailedReason,
 										},
 									},
 								},
@@ -510,6 +535,13 @@ func testClusterBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 										{
 											Type:    corev1alpha1.ConditionReady,
 											Status:  corev1.ConditionFalse,
+											Message: buildapi.NoLatestImageMessage,
+											Reason:  buildapi.NoLatestImageReason,
+										},
+										{
+											Type:    buildapi.ConditionUpToDate,
+											Status:  corev1.ConditionFalse,
+											Reason:  buildapi.ReconcileFailedReason,
 											Message: `clusterstore.kpack.io "some-store" not found`,
 										},
 									},
@@ -548,6 +580,13 @@ func testClusterBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 										{
 											Type:    corev1alpha1.ConditionReady,
 											Status:  corev1.ConditionFalse,
+											Message: buildapi.NoLatestImageMessage,
+											Reason:  buildapi.NoLatestImageReason,
+										},
+										{
+											Type:    buildapi.ConditionUpToDate,
+											Status:  corev1.ConditionFalse,
+											Reason:  buildapi.ReconcileFailedReason,
 											Message: `clusterstack.kpack.io "some-stack" not found`,
 										},
 									},

--- a/pkg/reconciler/image/build_required_test.go
+++ b/pkg/reconciler/image/build_required_test.go
@@ -800,6 +800,7 @@ func testImageBuilds(t *testing.T, when spec.G, it spec.S) {
 
 type TestBuilderResource struct {
 	BuilderReady     bool
+	BuilderUpToDate  bool
 	BuilderMetadata  []corev1alpha1.BuildpackMetadata
 	ImagePullSecrets []corev1.LocalObjectReference
 	LatestImage      string
@@ -818,6 +819,10 @@ func (t TestBuilderResource) BuildBuilderSpec() corev1alpha1.BuildBuilderSpec {
 
 func (t TestBuilderResource) Ready() bool {
 	return t.BuilderReady
+}
+
+func (t TestBuilderResource) UpToDate() bool {
+	return t.BuilderUpToDate
 }
 
 func (t TestBuilderResource) BuildpackMetadata() corev1alpha1.BuildpackMetadataList {


### PR DESCRIPTION
Adds a condition for Builder UpToDate. This tracks the status of the latest reconcile of the builder, while the Ready condition indicates that the builder is able to be used in a build. The reason behind this change is that a builder reconcile may fail for a variety of reasons, but as long as there is a latestImage, builds should be able to continue.

resolves #1365