### PR TITLE
Get dependabot to watch the `release/**` branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,25 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  # Monitor old release branches as well
+  - package-ecosystem: "gomod"
+    target-branch: "release/v0.12.x"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "gomod"
+    target-branch: "release/v0.11.x"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "gomod"
+    target-branch: "release/v0.10.x"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "gomod"
+    target-branch: "release/v0.9.x"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,6 +20,8 @@ To produce a major/minor release from `main` a maintainer will:
         - **release notes**
         - **asset checksums**
     - The release notes should be edited and cleaned
+- Add the new release branch as a `target-branch` to the [dependabot config][dependabot-config] so that dependency bump PRs can be opened against it
+    - Evaluate if support can be dropped for old release branches and remove them from the config
 
 ## Releasing a new Patch Version
 
@@ -45,3 +47,4 @@ To produce a patch release from an existing `release` branch a maintainer will:
 
 [release]: https://github.com/pivotal/kpack/releases
 [github-release]: https://github.com/pivotal/kpack/blob/main/.github/workflows/ci.yaml
+[dependabot-config]: ./.github/dependabot.yml


### PR DESCRIPTION
I haven't fully tested this and am not really sure how well this will turn out.

I don't think you can configure dependabot to only create security related dep bumps, so I assume we're gonna get hit by a bajillion PRs for the older releases.