### PR TITLE
Dependabot add version as label for older releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,21 +19,25 @@ updates:
   # Monitor old release branches as well
   - package-ecosystem: "gomod"
     target-branch: "release/v0.12.x"
+    labels: ["go", "dependencies", "release/v0.12.x"]
     directory: "/"
     schedule:
       interval: "weekly"
   - package-ecosystem: "gomod"
     target-branch: "release/v0.11.x"
+    labels: ["go", "dependencies", "release/v0.11.x"]
     directory: "/"
     schedule:
       interval: "weekly"
   - package-ecosystem: "gomod"
     target-branch: "release/v0.10.x"
+    labels: ["go", "dependencies", "release/v0.10.x"]
     directory: "/"
     schedule:
       interval: "weekly"
   - package-ecosystem: "gomod"
     target-branch: "release/v0.9.x"
+    labels: ["go", "dependencies", "release/v0.9.x"]
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Better glance value when looking at the Pull Requests page