### PR TITLE
[0.11.x] Bump lifecycle to 0.17.2

### DIFF
--- a/hack/lifecycle/main.go
+++ b/hack/lifecycle/main.go
@@ -33,7 +33,7 @@ import (
 const (
 	lifecycleMetadataLabel = "io.buildpacks.lifecycle.metadata"
 	lifecycleLocation      = "/cnb/lifecycle/"
-	lifecycleVersion       = "0.16.0"
+	lifecycleVersion       = "0.17.2"
 )
 
 var (


### PR DESCRIPTION
The lifecycle image is built with an older version of go that contains CVEs, this means that both the kpack deployment, the builder pod, and even the built app image will show up in scanners. By bumping to 0.17.2 (which is the highest backwards-compatible version), it at leasts resolves CVEs from the go stdlib (there's still go.mod CVEs, but not much we can do about that since lifecycle doesn't patch older versions).

The user facing changes would be that Buildpack API v0.9 and v0.10 would now be supported (we hard code the [supported Platform API versions](https://github.com/buildpacks-community/kpack/blob/main/pkg/cnb/builder_builder.go#L38)) . See https://github.com/buildpacks/lifecycle?tab=readme-ov-file#supported-apis for more details