### PR TITLE
Generate `project-metadata.toml` for all source types

### DIFF
--- a/cmd/build-init/main.go
+++ b/cmd/build-init/main.go
@@ -72,7 +72,7 @@ const (
 	platformDir                  = "/platform"
 	buildSecretsDir              = "/var/build-secrets"
 	registrySourcePullSecretsDir = "/registrySourcePullSecrets"
-	projectMetadataDir           = "/projectMetadata"
+	projectMetadataDir           = "/projectMetadata" // place to write project-metadata.toml which gets exported to image label by the lifecycle
 	networkWaitLauncherDir       = "/networkWait"
 	networkWaitLauncherBinary    = "network-wait-launcher.exe"
 )
@@ -223,7 +223,7 @@ func fetchSource(logger *log.Logger, keychain authn.Keychain) error {
 		fetcher := blob.Fetcher{
 			Logger: logger,
 		}
-		return fetcher.Fetch(appDir, *blobURL, *stripComponents)
+		return fetcher.Fetch(appDir, *blobURL, *stripComponents, projectMetadataDir)
 	case *registryImage != "":
 		registrySourcePullSecrets, err := dockercreds.ParseDockerConfigSecret(registrySourcePullSecretsDir)
 		if err != nil {
@@ -235,7 +235,7 @@ func fetchSource(logger *log.Logger, keychain authn.Keychain) error {
 			Client:   &registry.Client{},
 			Keychain: authn.NewMultiKeychain(registrySourcePullSecrets, keychain),
 		}
-		return fetcher.Fetch(appDir, *registryImage)
+		return fetcher.Fetch(appDir, *registryImage, projectMetadataDir)
 	default:
 		return errors.New("no git url, blob url, or registry image provided")
 	}

--- a/pkg/git/fetch_test.go
+++ b/pkg/git/fetch_test.go
@@ -25,8 +25,10 @@ func testGitCheckout(t *testing.T, when spec.G, it spec.S) {
 			Logger:   log.New(outputBuffer, "", 0),
 			Keychain: fakeGitKeychain{},
 		}
-		var testDir string
-		var metadataDir string
+		var (
+			testDir     string
+			metadataDir string
+		)
 
 		it.Before(func() {
 			var err error
@@ -102,21 +104,39 @@ func testGitCheckout(t *testing.T, when spec.G, it spec.S) {
 			require.False(t, isExecutableByAny(fileInfo.Mode()))
 		})
 
+		it("records project-metadata.toml", func() {
+			err := fetcher.Fetch(testDir, "https://github.com/git-fixtures/basic", "b029517f6300c2da0f4b651b8642506cd6aaf45d", metadataDir)
+			require.NoError(t, err)
+
+			p := path.Join(metadataDir, "project-metadata.toml")
+			contents, err := os.ReadFile(p)
+			require.NoError(t, err)
+
+			expectedFile := `[source]
+  type = "git"
+  [source.metadata]
+    repository = "https://github.com/git-fixtures/basic"
+    revision = "b029517f6300c2da0f4b651b8642506cd6aaf45d"
+  [source.version]
+    commit = "b029517f6300c2da0f4b651b8642506cd6aaf45d"
+`
+			require.Equal(t, expectedFile, string(contents))
+		})
+
 		it("returns invalid credentials to fetch error on authentication required", func() {
 			err := fetcher.Fetch(testDir, "git@bitbucket.com:org/repo", "main", metadataDir)
 			require.ErrorContains(t, err, "unable to fetch references for repository")
 		})
 
-        it("initializes submodules", func() {
-            fetcher.InitializeSubmodules = true 
-            err := fetcher.Fetch(testDir, "https://github.com/git-fixtures/submodule", "master", metadataDir)
-            require.NoError(t, err)
-
-            _, err = os.Lstat(path.Join(testDir, "basic", ".gitignore"))
+		it("initializes submodules", func() {
+			fetcher.InitializeSubmodules = true
+			err := fetcher.Fetch(testDir, "https://github.com/git-fixtures/submodule", "master", metadataDir)
 			require.NoError(t, err)
 
+			_, err = os.Lstat(path.Join(testDir, "basic", ".gitignore"))
+			require.NoError(t, err)
 
-        })
+		})
 	})
 }
 


### PR DESCRIPTION
We're currently only generating it for the `git` source type