### PR TITLE
Revert "Support subfolder reconciliation logic"

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -90,7 +90,7 @@ The `source` field is a composition of a source code location and a `subpath`. I
         - `url`: The git repository url. Both https and ssh formats are supported; with ssh format requiring a [ssh secret](secrets.md#git-secrets).
         - `revision`: The git revision to use. This value may be a commit sha, branch name, or tag.
         - `initializeSubmodules`: Initialize submodules inside repo, recurses up to a max depth of 10 submodules.
-    - `subPath`: A subdirectory within the source folder where application code resides. New builds will only be created if a change was made in this directory. Can be ignored if the source code resides at the `root` level.
+    - `subPath`: A subdirectory within the source folder where application code resides. Can be ignored if the source code resides at the `root` level.
 
 * Blob
 

--- a/pkg/git/remote_git_resolver.go
+++ b/pkg/git/remote_git_resolver.go
@@ -1,66 +1,20 @@
 package git
 
 import (
-	"path"
-	"regexp"
-	"strings"
-
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/storage/memory"
+
 	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
 )
 
 const defaultRemote = "origin"
 
-var regex = regexp.MustCompile("[a-f0-9]{40}")
-
 type remoteGitResolver struct{}
 
 func (*remoteGitResolver) Resolve(auth transport.AuthMethod, sourceConfig corev1alpha1.SourceConfig) (corev1alpha1.ResolvedSourceConfig, error) {
-	var resolvedConfig corev1alpha1.ResolvedSourceConfig
-	var err error
-
-	if sourceConfig.SubPath == "." {
-		sourceConfig.SubPath = ""
-	}
-
-	if sourceConfig.SubPath != "" {
-		resolvedConfig, err = resolveSourceWithSubpath(auth, sourceConfig)
-	} else {
-		resolvedConfig, err = resolveSourceWithoutSubpath(auth, sourceConfig)
-	}
-
-	if err != nil {
-		resolvedConfig = corev1alpha1.ResolvedSourceConfig{
-			Git: &corev1alpha1.ResolvedGitSource{
-				URL:                  sourceConfig.Git.URL,
-				Revision:             sourceConfig.Git.Revision,
-				Type:                 corev1alpha1.Unknown,
-				SubPath:              sourceConfig.SubPath,
-				InitializeSubmodules: sourceConfig.Git.InitializeSubmodules,
-			},
-		}
-	}
-
-	if resolvedConfig.ResolvedSource() == nil {
-		resolvedConfig = corev1alpha1.ResolvedSourceConfig{
-			Git: &corev1alpha1.ResolvedGitSource{
-				URL:                  sourceConfig.Git.URL,
-				Revision:             sourceConfig.Git.Revision,
-				Type:                 corev1alpha1.Commit,
-				SubPath:              sourceConfig.SubPath,
-				InitializeSubmodules: sourceConfig.Git.InitializeSubmodules,
-			},
-		}
-	}
-
-	return resolvedConfig, err
-}
-
-func resolveSourceWithoutSubpath(auth transport.AuthMethod, sourceConfig corev1alpha1.SourceConfig) (corev1alpha1.ResolvedSourceConfig, error) {
 	remote := gogit.NewRemote(memory.NewStorage(), &config.RemoteConfig{
 		Name: defaultRemote,
 		URLs: []string{sourceConfig.Git.URL},
@@ -69,6 +23,17 @@ func resolveSourceWithoutSubpath(auth transport.AuthMethod, sourceConfig corev1a
 	refs, err := remote.List(&gogit.ListOptions{
 		Auth: auth,
 	})
+	if err != nil {
+		return corev1alpha1.ResolvedSourceConfig{
+			Git: &corev1alpha1.ResolvedGitSource{
+				URL:                  sourceConfig.Git.URL,
+				Revision:             sourceConfig.Git.Revision,
+				Type:                 corev1alpha1.Unknown,
+				SubPath:              sourceConfig.SubPath,
+				InitializeSubmodules: sourceConfig.Git.InitializeSubmodules,
+			},
+		}, nil
+	}
 
 	for _, ref := range refs {
 		if ref.Name().Short() == sourceConfig.Git.Revision {
@@ -83,65 +48,16 @@ func resolveSourceWithoutSubpath(auth transport.AuthMethod, sourceConfig corev1a
 			}, nil
 		}
 	}
-	return corev1alpha1.ResolvedSourceConfig{}, err
-}
 
-func resolveSourceWithSubpath(auth transport.AuthMethod, sourceConfig corev1alpha1.SourceConfig) (corev1alpha1.ResolvedSourceConfig, error) {
-	var resolvedConfig corev1alpha1.ResolvedSourceConfig
-
-	r, err := gogit.Clone(memory.NewStorage(), nil, &gogit.CloneOptions{
-		URL:  sourceConfig.Git.URL,
-		Auth: auth,
-	})
-
-	rIter, _ := r.References()
-
-	rIter.ForEach(func(ref *plumbing.Reference) error {
-		if ref.Name().Short() == sourceConfig.Git.Revision {
-			refSourceType := sourceType(ref)
-			effectiveCommit := ""
-
-			if refSourceType == corev1alpha1.Branch {
-				effectiveCommit, err = latestCommitForSubpath(r, path.Clean(sourceConfig.SubPath))
-			} else {
-				effectiveCommit = ref.Hash().String()
-			}
-
-			if err != nil {
-				return nil
-			}
-
-			resolvedConfig = corev1alpha1.ResolvedSourceConfig{
-				Git: &corev1alpha1.ResolvedGitSource{
-					URL:                  sourceConfig.Git.URL,
-					Revision:             effectiveCommit,
-					Type:                 refSourceType,
-					SubPath:              sourceConfig.SubPath,
-					InitializeSubmodules: sourceConfig.Git.InitializeSubmodules,
-				},
-			}
-		}
-		return nil
-	})
-
-	return resolvedConfig, err
-}
-
-func latestCommitForSubpath(r *gogit.Repository, subPath string) (string, error) {
-	logOutput, err := r.Log(&gogit.LogOptions{
-		PathFilter: func(s string) bool {
-			if strings.HasPrefix(s, subPath) {
-				return true
-			} else {
-				return false
-			}
+	return corev1alpha1.ResolvedSourceConfig{
+		Git: &corev1alpha1.ResolvedGitSource{
+			URL:                  sourceConfig.Git.URL,
+			Revision:             sourceConfig.Git.Revision,
+			Type:                 corev1alpha1.Commit,
+			SubPath:              sourceConfig.SubPath,
+			InitializeSubmodules: sourceConfig.Git.InitializeSubmodules,
 		},
-	})
-
-	latestCommit, err := logOutput.Next()
-	effectiveCommit := regex.FindString(latestCommit.String())
-
-	return effectiveCommit, err
+	}, nil
 }
 
 func sourceType(reference *plumbing.Reference) corev1alpha1.GitSourceKind {

--- a/pkg/git/remote_git_resolver_test.go
+++ b/pkg/git/remote_git_resolver_test.go
@@ -17,12 +17,11 @@ func TestRemoteGitResolver(t *testing.T) {
 
 func testRemoteGitResolver(t *testing.T, when spec.G, it spec.S) {
 	const (
-		url                              = "https://github.com/git-fixtures/basic.git"
-		nonHEADCommit                    = "a755256fc0a57241b92167eb748b333449a3d7e9"
-		fixtureHEADMasterCommit          = "6ecf0ef2c2dffb796033e5a02219af86ec6584e5"
-		fixtureHEADMasterEffectiveCommit = "918c48b83bd081e863dbe1b80f8998f058cd8294"
-		tag                              = "commit-tag"
-		tagCommit                        = "ad7897c0fb8e7d9a9ba41fa66072cf06095a6cfc"
+		url                     = "https://github.com/git-fixtures/basic.git"
+		nonHEADCommit           = "a755256fc0a57241b92167eb748b333449a3d7e9"
+		fixtureHEADMasterCommit = "6ecf0ef2c2dffb796033e5a02219af86ec6584e5"
+		tag                     = "commit-tag"
+		tagCommit               = "ad7897c0fb8e7d9a9ba41fa66072cf06095a6cfc"
 	)
 
 	when("#Resolve", func() {
@@ -50,7 +49,7 @@ func testRemoteGitResolver(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 
-		when("source is a branch with latest commit", func() {
+		when("source is a branch", func() {
 			it("returns branch with resolved commit", func() {
 				gitResolver := remoteGitResolver{}
 
@@ -59,6 +58,7 @@ func testRemoteGitResolver(t *testing.T, when spec.G, it spec.S) {
 						URL:      url,
 						Revision: "master",
 					},
+					SubPath: "/foo/bar",
 				})
 				require.NoError(t, err)
 
@@ -67,53 +67,7 @@ func testRemoteGitResolver(t *testing.T, when spec.G, it spec.S) {
 						URL:      url,
 						Revision: fixtureHEADMasterCommit,
 						Type:     corev1alpha1.Branch,
-					},
-				}, resolvedGitSource)
-			})
-		})
-
-		when("source is a branch with latest commit and a . subpath", func() {
-			it("returns branch with resolved commit", func() {
-				gitResolver := remoteGitResolver{}
-
-				resolvedGitSource, err := gitResolver.Resolve(anonymousAuth, corev1alpha1.SourceConfig{
-					Git: &corev1alpha1.Git{
-						URL:      url,
-						Revision: "master",
-					},
-					SubPath: ".",
-				})
-				require.NoError(t, err)
-
-				assert.Equal(t, corev1alpha1.ResolvedSourceConfig{
-					Git: &corev1alpha1.ResolvedGitSource{
-						URL:      url,
-						Revision: fixtureHEADMasterCommit,
-						Type:     corev1alpha1.Branch,
-					},
-				}, resolvedGitSource)
-			})
-		})
-
-		when("source is a branch with older subpath", func() {
-			it("returns branch with resolved commit", func() {
-				gitResolver := remoteGitResolver{}
-
-				resolvedGitSource, err := gitResolver.Resolve(anonymousAuth, corev1alpha1.SourceConfig{
-					Git: &corev1alpha1.Git{
-						URL:      url,
-						Revision: "master",
-					},
-					SubPath: "go/",
-				})
-				require.NoError(t, err)
-
-				assert.Equal(t, corev1alpha1.ResolvedSourceConfig{
-					Git: &corev1alpha1.ResolvedGitSource{
-						URL:      url,
-						Revision: fixtureHEADMasterEffectiveCommit,
-						Type:     corev1alpha1.Branch,
-						SubPath:  "go/",
+						SubPath:  "/foo/bar",
 					},
 				}, resolvedGitSource)
 			})


### PR DESCRIPTION
Reverts buildpacks-community/kpack#1358

#1358 loads the git history into memory, which greatly increased the memory footprint of kpack. On our test environment, we were using https://github.com/paketo-buildpacks/samples and noticed it was using >200mb of memory **per Image**, up from 1-5mb per Image in release v0.12.3.

That figure is a bit deceptive since it varies wildly depending on the size of the `.git` folder in your repo (for example, this repo adds around 50mb). Regardless, I think it's way too much of an increase to be considered reasonable.

I'm going to revert this PR and reopen the issue to see if we can approach it in some different way.