### PR TITLE
Shorten service binding secret volume mount names

### DIFF
--- a/pkg/apis/build/v1alpha2/build_pod.go
+++ b/pkg/apis/build/v1alpha2/build_pod.go
@@ -1135,7 +1135,7 @@ func setupBindingVolumesAndMounts(bindings []ServiceBinding) ([]corev1.Volume, [
 		switch b := binding.(type) {
 		case *corev1alpha1.ServiceBinding:
 			if b.SecretRef != nil {
-				secretVolume := fmt.Sprintf("service-binding-secret-%s", b.Name)
+				secretVolume := fmt.Sprintf("binding-%s", b.Name)
 				volumes = append(volumes,
 					corev1.Volume{
 						Name: secretVolume,

--- a/pkg/apis/build/v1alpha2/build_pod_test.go
+++ b/pkg/apis/build/v1alpha2/build_pod_test.go
@@ -440,7 +440,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 			assert.Contains(t,
 				pod.Spec.Volumes,
 				corev1.Volume{
-					Name: "service-binding-secret-database",
+					Name: "binding-database",
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
 							SecretName: "database",
@@ -448,7 +448,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 					},
 				},
 				corev1.Volume{
-					Name: "service-binding-secret-apm",
+					Name: "binding-apm",
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
 							SecretName: "apm",
@@ -461,12 +461,12 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 				assert.Contains(t,
 					pod.Spec.InitContainers[containerIdx].VolumeMounts,
 					corev1.VolumeMount{
-						Name:      "service-binding-secret-database",
+						Name:      "binding-database",
 						MountPath: "/platform/bindings/database",
 						ReadOnly:  true,
 					},
 					corev1.VolumeMount{
-						Name:      "service-binding-secret-apm",
+						Name:      "binding-apm",
 						MountPath: "/platform/bindings/apm",
 						ReadOnly:  true,
 					},
@@ -728,8 +728,8 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 				"layers-dir",
 				"platform-dir",
 				"workspace-dir",
-				"service-binding-secret-database",
-				"service-binding-secret-apm",
+				"binding-database",
+				"binding-apm",
 			}, names(pod.Spec.InitContainers[2].VolumeMounts))
 		})
 
@@ -843,8 +843,8 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 				"layers-dir",
 				"platform-dir",
 				"workspace-dir",
-				"service-binding-secret-database",
-				"service-binding-secret-apm",
+				"binding-database",
+				"binding-apm",
 			}, names(pod.Spec.InitContainers[4].VolumeMounts))
 		})
 


### PR DESCRIPTION
The volume name has a limit of 63 characters. Using the `service-binding-secret-` prefix exhaust a significant part of this limit. Given that the binding name is a user input it is not too hard to hit that limit.

While this PR solves our immediate problem, you could consider whether shortening all the volume names makes sense. One way of keeping names within the limit is to use a name of `sha-1(prefix+binding-name)`
