### PR TITLE
Update fetch.go to include a Depth specifier

### DIFF
--- a/pkg/git/fetch.go
+++ b/pkg/git/fetch.go
@@ -50,6 +50,7 @@ func (f Fetcher) Fetch(dir, gitURL, gitRevision, metadataDir string) error {
 	err = remote.Fetch(&gogit.FetchOptions{
 		RefSpecs: []config.RefSpec{"refs/*:refs/*"},
 		Auth:     auth,
+		Depth:     1,
 	})
 	if err != nil && err != transport.ErrAuthenticationRequired {
 		return errors.Wrapf(err, "unable to fetch references for repository")

--- a/pkg/git/fetch.go
+++ b/pkg/git/fetch.go
@@ -51,6 +51,7 @@ func (f Fetcher) Fetch(dir, gitURL, gitRevision, metadataDir string) error {
 		RefSpecs: []config.RefSpec{"refs/*:refs/*"},
 		Auth:     auth,
 		Depth:     1,
+		Force:    true,
 	})
 	if err != nil && err != transport.ErrAuthenticationRequired {
 		return errors.Wrapf(err, "unable to fetch references for repository")

--- a/pkg/git/fetch.go
+++ b/pkg/git/fetch.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
 	"log"
 	"os"
 	"path"
@@ -47,11 +48,23 @@ func (f Fetcher) Fetch(dir, gitURL, gitRevision, metadataDir string) error {
 		return errors.Wrap(err, "creating remote")
 	}
 
+	resolver := &remoteGitResolver{}
+	resolvedSourceConfig, err := resolver.Resolve(auth, corev1alpha1.SourceConfig{
+		Git: &corev1alpha1.Git{
+			URL:                  gitURL,
+			Revision:             gitRevision,
+			InitializeSubmodules: f.InitializeSubmodules,
+		},
+		SubPath: "",
+	})
+	if err != nil {
+		return errors.Wrap(err, "resolving source config")
+	}
+
 	err = remote.Fetch(&gogit.FetchOptions{
-		RefSpecs: []config.RefSpec{"refs/*:refs/*"},
+		RefSpecs: []config.RefSpec{config.RefSpec(resolvedSourceConfig.Git.Revision + ":" + resolvedSourceConfig.Git.Revision)},
 		Auth:     auth,
-		Depth:     1,
-		Force:    true,
+		Depth:    1,
 	})
 	if err != nil && err != transport.ErrAuthenticationRequired {
 		return errors.Wrapf(err, "unable to fetch references for repository")
@@ -64,12 +77,10 @@ func (f Fetcher) Fetch(dir, gitURL, gitRevision, metadataDir string) error {
 		return errors.Wrapf(err, "getting worktree for repository")
 	}
 
-	hash, err := repository.ResolveRevision(plumbing.Revision(gitRevision))
-	if err != nil {
-		return errors.Wrapf(err, "resolving revision")
-	}
+	//resolvedSourceConfig.Git.Revision is the hash of the commit
+	hash := plumbing.NewHash(resolvedSourceConfig.Git.Revision)
 
-	err = worktree.Checkout(&gogit.CheckoutOptions{Hash: *hash})
+	err = worktree.Checkout(&gogit.CheckoutOptions{Hash: hash})
 	if err != nil {
 		return errors.Wrapf(err, "checking out revision")
 	}

--- a/pkg/git/fetch_test.go
+++ b/pkg/git/fetch_test.go
@@ -79,7 +79,7 @@ func testGitCheckout(t *testing.T, when spec.G, it spec.S) {
 
 		it("returns error on non-existent ref", func() {
 			err := fetcher.Fetch(testDir, "https://github.com/git-fixtures/basic", "doesnotexist", metadataDir)
-			require.EqualError(t, err, "resolving revision: reference not found")
+			require.EqualError(t, err, "unable to fetch references for repository: couldn't find remote ref \"doesnotexist\"")
 		})
 
 		it("preserves symbolic links", func() {


### PR DESCRIPTION
For repositories with large histories, since there doesn't appear to be caching of the git repository, we shouldn't pull all history as it's not needed for the purpose of building.  This one line change significantly improves build performance when irrelevant git history is large.