### PR TITLE
Adopters: Korifi

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -6,5 +6,6 @@ Below is a list of projects that have publicly adopted kpack.
 * [Bloomberg](https://www.techatbloomberg.com/)
 * [VMware Tanzu Build Service](https://tanzu.vmware.com/build-service)
 * [Azure Spring Apps](https://azure.microsoft.com/en-us/products/spring-apps)
+* [Korifi](https://www.cloudfoundry.org/technology/korifi/)
 
 If you'd like to be added, feel free to [open a pull-request!](https://github.com/pivotal/kpack/pulls)

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -8,4 +8,4 @@ Below is a list of projects that have publicly adopted kpack.
 * [Azure Spring Apps](https://azure.microsoft.com/en-us/products/spring-apps)
 * [Korifi](https://www.cloudfoundry.org/technology/korifi/)
 
-If you'd like to be added, feel free to [open a pull-request!](https://github.com/pivotal/kpack/pulls)
+If you'd like to be added, feel free to [open a pull-request!](https://github.com/buildpacks-community/kpack/pulls)


### PR DESCRIPTION
The Cloud Foundry project Korifi is using kpack.

While I was in the ADOPTERS.md file, I've corrected the link to open a PR against this repository.