### PR TITLE
Enable using cache registry for the first build

### DIFF
--- a/pkg/apis/build/v1alpha2/build_pod.go
+++ b/pkg/apis/build/v1alpha2/build_pod.go
@@ -269,6 +269,8 @@ func (b *Build) BuildPod(images BuildPodImages, buildContext BuildContext) (*cor
 		useCacheFromLastBuild := b.Spec.LastBuild != nil && b.Spec.LastBuild.Cache.Image != ""
 		if useCacheFromLastBuild {
 			genericCacheArgs = []string{fmt.Sprintf("-cache-image=%s", b.Spec.LastBuild.Cache.Image)}
+		} else {
+			genericCacheArgs = []string{fmt.Sprintf("-cache-image=%s", b.Spec.Cache.Registry.Tag)}
 		}
 		analyzerCacheArgs = genericCacheArgs
 		exporterCacheArgs = []string{fmt.Sprintf("-cache-image=%s", b.Spec.Cache.Registry.Tag)}

--- a/pkg/apis/build/v1alpha2/build_pod_test.go
+++ b/pkg/apis/build/v1alpha2/build_pod_test.go
@@ -1073,7 +1073,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 					podWithImageCache, err := build.BuildPod(config, buildContext)
 					require.NoError(t, err)
 
-					restoreContainer := podWithImageCache.Spec.InitContainers[3]
+					restoreContainer := firstContainerByName(podWithImageCache.Spec.InitContainers, "restore")
 					assert.Contains(t, restoreContainer.Args, "-cache-image=test-cache-image")
 				})
 				it("adds the cache to export container", func() {

--- a/pkg/apis/build/v1alpha2/build_pod_test.go
+++ b/pkg/apis/build/v1alpha2/build_pod_test.go
@@ -1053,19 +1053,19 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 					assert.Len(t, podWithImageCache.Spec.Volumes, len(podWithVolumeCache.Spec.Volumes)-1)
 				})
 
-				it("does not add the cache to analyze container", func() {
+				it("does add the cache to analyze container", func() {
 					podWithImageCache, err := build.BuildPod(config, buildContext)
 					require.NoError(t, err)
 
 					analyzeContainer := podWithImageCache.Spec.InitContainers[2]
-					assert.NotContains(t, analyzeContainer.Args, "-cache-image=test-cache-image")
+					assert.Contains(t, analyzeContainer.Args, "-cache-image=test-cache-image")
 				})
-				it("does not add the cache to restore container", func() {
+				it("does add cache to restore container", func() {
 					podWithImageCache, err := build.BuildPod(config, buildContext)
 					require.NoError(t, err)
 
 					restoreContainer := podWithImageCache.Spec.InitContainers[3]
-					assert.NotContains(t, restoreContainer.Args, "-cache-image=test-cache-image")
+					assert.Contains(t, restoreContainer.Args, "-cache-image=test-cache-image")
 				})
 				it("adds the cache to export container", func() {
 					podWithImageCache, err := build.BuildPod(config, buildContext)

--- a/pkg/apis/build/v1alpha2/build_pod_test.go
+++ b/pkg/apis/build/v1alpha2/build_pod_test.go
@@ -24,6 +24,15 @@ func TestBuildPod(t *testing.T) {
 	spec.Run(t, "Test Build Pod", testBuildPod)
 }
 
+func firstContainerByName(containers []corev1.Container, name string) corev1.Container {
+	for _, c := range containers {
+		if c.Name == name {
+			return c
+		}
+	}
+	return corev1.Container{}
+}
+
 func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 	const (
 		namespace        = "some-namespace"
@@ -1057,7 +1066,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 					podWithImageCache, err := build.BuildPod(config, buildContext)
 					require.NoError(t, err)
 
-					analyzeContainer := podWithImageCache.Spec.InitContainers[2]
+					analyzeContainer := firstContainerByName(podWithImageCache.Spec.InitContainers, "analyze")
 					assert.Contains(t, analyzeContainer.Args, "-cache-image=test-cache-image")
 				})
 				it("does add cache to restore container", func() {


### PR DESCRIPTION
Registry caching was disabled for the first build although it permits to share cache between images. This will speed lot of first builds.