### PR TITLE
Bump lifecycle image to 0.20.5

### DIFF
--- a/hack/lifecycle/main.go
+++ b/hack/lifecycle/main.go
@@ -32,7 +32,7 @@ import (
 const (
 	lifecycleMetadataLabel = "io.buildpacks.lifecycle.metadata"
 	lifecycleLocation      = "/cnb/lifecycle/"
-	lifecycleVersion       = "0.20.0"
+	lifecycleVersion       = "0.20.5"
 )
 
 var (


### PR DESCRIPTION
The lifecycle image shipped in our v0.16.0 release wasn't the latest.