### PR TITLE
feat: allow buildpacks with empty stacks

### DIFF
--- a/pkg/cnb/buildpack_validation.go
+++ b/pkg/cnb/buildpack_validation.go
@@ -18,6 +18,11 @@ func (bl BuildpackLayerInfo) supports(buildpackApis []string, id string, mixins 
 		return errors.Errorf("unsupported buildpack api: %s, expecting: %s", bl.API, strings.Join(buildpackApis, ", "))
 	}
 
+	// as of buildpack API 0.10+ stacks are optional (and deprecated)
+	if len(bl.Stacks) == 0 {
+		return nil
+	}
+
 	for _, s := range bl.Stacks {
 		buildpackVersion, err := semver.NewVersion(bl.API)
 		if err != nil {

--- a/pkg/cnb/create_builder_test.go
+++ b/pkg/cnb/create_builder_test.go
@@ -699,6 +699,26 @@ func testCreateBuilderOs(os string, t *testing.T, when spec.G, it spec.S) {
 				require.EqualError(t, err, "validating buildpack io.buildpack.unsupported.stack@v4: stack io.buildpacks.stacks.some-stack is not supported")
 			})
 
+			it("works with empty stack", func() {
+				addBuildpack(t, "io.buildpack.empty.stack", "v4", "buildpack.4.com", "0.2", []corev1alpha1.BuildpackStack{})
+
+				clusterBuilderSpec.Order = []buildapi.BuilderOrderEntry{
+					{
+						Group: []buildapi.BuilderBuildpackRef{{
+							BuildpackRef: corev1alpha1.BuildpackRef{
+								BuildpackInfo: corev1alpha1.BuildpackInfo{
+									Id:      "io.buildpack.empty.stack",
+									Version: "v4",
+								},
+							},
+						}},
+					},
+				}
+
+				_, err := subject.CreateBuilder(ctx, builderKeychain, stackKeychain, fetcher, stack, clusterBuilderSpec, []*corev1.Secret{}, builderTag)
+				require.NoError(t, err)
+			})
+
 			it("errors with unsupported mixin", func() {
 				addBuildpack(t, "io.buildpack.unsupported.mixin", "v4", "buildpack.1.com", "0.2",
 					[]corev1alpha1.BuildpackStack{


### PR DESCRIPTION
As of 0.10, stacks are deprecated and optional:

https://github.com/buildpacks/spec/blob/buildpack/v0.10/buildpack.md#buildpacktoml-toml-stacks-array

This allows the stacks to be empty during validation.

Fixes #1730