### PR TITLE
Migrate images to GHCR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,9 +49,9 @@ jobs:
     - name: Docker Login
       uses: docker/login-action@v3.3.0
       with:
-        registry: ${{ secrets.REGISTRY_HOST }}
-        username: ${{ secrets.REGISTRY_USER }}
-        password: ${{ secrets.REGISTRY_PASSWORD }}
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build
       uses: ./.github/actions/pack-build
       with:
@@ -68,9 +68,9 @@ jobs:
     - name: Docker Login
       uses: docker/login-action@v3.3.0
       with:
-        registry: ${{ secrets.REGISTRY_HOST }}
-        username: ${{ secrets.REGISTRY_USER }}
-        password: ${{ secrets.REGISTRY_PASSWORD }}
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build
       uses: ./.github/actions/pack-build
       with:
@@ -87,9 +87,9 @@ jobs:
     - name: Docker Login
       uses: docker/login-action@v3.3.0
       with:
-        registry: ${{ secrets.REGISTRY_HOST }}
-        username: ${{ secrets.REGISTRY_USER }}
-        password: ${{ secrets.REGISTRY_PASSWORD }}
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build
       uses: ./.github/actions/pack-build
       with:
@@ -106,9 +106,9 @@ jobs:
     - name: Docker Login
       uses: docker/login-action@v3.3.0
       with:
-        registry: ${{ secrets.REGISTRY_HOST }}
-        username: ${{ secrets.REGISTRY_USER }}
-        password: ${{ secrets.REGISTRY_PASSWORD }}
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build
       uses: ./.github/actions/pack-build
       with:
@@ -125,9 +125,9 @@ jobs:
     - name: Docker Login
       uses: docker/login-action@v3.3.0
       with:
-        registry: ${{ secrets.REGISTRY_HOST }}
-        username: ${{ secrets.REGISTRY_USER }}
-        password: ${{ secrets.REGISTRY_PASSWORD }}
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build
       uses: ./.github/actions/pack-build
       with:
@@ -144,9 +144,9 @@ jobs:
     - name: Docker Login
       uses: docker/login-action@v3.3.0
       with:
-        registry: ${{ secrets.REGISTRY_HOST }}
-        username: ${{ secrets.REGISTRY_USER }}
-        password: ${{ secrets.REGISTRY_PASSWORD }}
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build
       uses: ./.github/actions/pack-build
       with:
@@ -446,9 +446,9 @@ jobs:
     - name: Docker Login
       uses: docker/login-action@v3.3.0
       with:
-        registry: ${{ secrets.REGISTRY_HOST }}
-        username: ${{ secrets.REGISTRY_USER }}
-        password: ${{ secrets.REGISTRY_PASSWORD }}
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Parse tag name
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ env:
   PUBLIC_IMAGE_DEV_REPO: ${{ vars.PUBLIC_IMAGE_DEV_REPO }}
   PUBLIC_IMAGE_REPO: ${{ vars.PUBLIC_IMAGE_REPO }}
   PACK_VERSION: ${{ vars.PACK_VERSION }}
-  LIFECYCLE_IMAGE_REF: buildpacksio/lifecycle
+  LIFECYCLE_IMAGE_REF: mirror.gcr.io/buildpacksio/lifecycle
 
 jobs:
   unit:

--- a/test/config.go
+++ b/test/config.go
@@ -35,6 +35,10 @@ type dockerConfigJson struct {
 	Auths dockerCredentials `json:"auths"`
 }
 
+const (
+	lifecycleImage = "mirror.gcr.io/buildpacksio/lifecycle"
+)
+
 func loadConfig(t *testing.T) config {
 	gitPrivateRepo, _ := os.LookupEnv("GIT_PRIVATE_REPO")
 	gitUsername, _ := os.LookupEnv("GIT_BASIC_USERNAME")

--- a/test/cosign_e2e_test.go
+++ b/test/cosign_e2e_test.go
@@ -47,6 +47,13 @@ func testSignBuilder(t *testing.T, _ spec.G, it spec.S) {
 	)
 
 	it.Before(func() {
+		// register a cleanup function that dumps crds only if the test fails
+		t.Cleanup(func() {
+			if t.Failed() {
+				dumpK8s(t, ctx, clients, testNamespace)
+			}
+		})
+
 		cfg = loadConfig(t)
 		builtImages = map[string]struct{}{}
 
@@ -187,7 +194,7 @@ func testSignBuilder(t *testing.T, _ spec.G, it spec.S) {
 				Name: clusterLifecycleName,
 			},
 			Spec: buildapi.ClusterLifecycleSpec{
-				ImageSource: corev1alpha1.ImageSource{Image: "buildpacksio/lifecycle"},
+				ImageSource: corev1alpha1.ImageSource{Image: lifecycleImage},
 			},
 		}, metav1.CreateOptions{})
 		require.NoError(t, err)

--- a/test/execute_build_test.go
+++ b/test/execute_build_test.go
@@ -269,7 +269,7 @@ func testCreateImage(t *testing.T, _ spec.G, it spec.S) {
 				Name: clusterLifecycleName,
 			},
 			Spec: buildapi.ClusterLifecycleSpec{
-				ImageSource: corev1alpha1.ImageSource{Image: "buildpacksio/lifecycle"},
+				ImageSource: corev1alpha1.ImageSource{Image: lifecycleImage},
 			},
 		}, metav1.CreateOptions{})
 		require.NoError(t, err)

--- a/test/slsa_test.go
+++ b/test/slsa_test.go
@@ -74,6 +74,13 @@ func testSlsaBuild(t *testing.T, when spec.G, it spec.S) {
 	)
 
 	it.Before(func() {
+		// register a cleanup function that dumps crds only if the test fails
+		t.Cleanup(func() {
+			if t.Failed() {
+				dumpK8s(t, ctx, clients, testNamespace)
+			}
+		})
+
 		cfg = loadConfig(t)
 		builtImages = map[string]struct{}{}
 
@@ -215,7 +222,7 @@ func testSlsaBuild(t *testing.T, when spec.G, it spec.S) {
 				Name: clusterLifecycleName,
 			},
 			Spec: buildapi.ClusterLifecycleSpec{
-				ImageSource: corev1alpha1.ImageSource{Image: "buildpacksio/lifecycle"},
+				ImageSource: corev1alpha1.ImageSource{Image: lifecycleImage},
 			},
 		}, metav1.CreateOptions{})
 		require.NoError(t, err)

--- a/test/testhelpers.go
+++ b/test/testhelpers.go
@@ -36,6 +36,12 @@ func printObject(t *testing.T, obj interface{}) {
 
 func dumpK8s(t *testing.T, ctx context.Context, clients *clients, namespace string) {
 	const header = "=================%v=================\n"
+	t.Logf(header, "ClusterLifecycles")
+	clusterLifecycles, err := clients.client.KpackV1alpha2().ClusterLifecycles().List(ctx, metav1.ListOptions{})
+	require.NoError(t, err)
+	for _, cl := range clusterLifecycles.Items {
+		printObject(t, cl)
+	}
 
 	t.Logf(header, "ClusterBuilders")
 	clusterBuilders, err := clients.client.KpackV1alpha2().ClusterBuilders().List(ctx, metav1.ListOptions{})


### PR DESCRIPTION
Closes #1385, #1836

The current GAR repository the kpack images are published to is owned by Broadcom. We've been informed that this GCP project will be shut down as per Broadcom policy that all GCP projects needs to be internal and behind a firewall.

So this PR moves the destination for both dev (aka nightly) and release images to ghcr.io

There's also a small change in here to use a mirror for the lifecycle image as we were getting throttled by index.docker.io