### PR TITLE
Updating lifecycle image registry for local development

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -68,6 +68,9 @@ function generate_kbld_config_pack() {
       build:
         builder: paketobuildpacks/builder-jammy-tiny
         rawOptions: [${completion_args// /,}]
+  overrides:
+    - image: lifecycle
+      newImage: mirror.gcr.io/buildpacksio/lifecycle
   destinations:
   - image: controller
     newImage: $controller_image
@@ -127,6 +130,9 @@ function generate_kbld_config_ko() {
     ko:
       build:
         rawOptions: [${args// /,}]
+  overrides:
+  - image: lifecycle
+    newImage: mirror.gcr.io/buildpacksio/lifecycle
   destinations:
   - image: controller
     newImage: $controller_image


### PR DESCRIPTION
While running script `hack/local.sh` to setup the sandbox env, build failed as it was unable to find the `lifecycle` introduced in #1849. Since there is not a default image in the schema, we have to provide an `override` in the kbld config.