### PR TITLE
Extends builds.kpack.io with a new optional field spec.builder.ref

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -7187,6 +7187,10 @@
           "x-kubernetes-list-type": "",
           "x-kubernetes-patch-merge-key": "name",
           "x-kubernetes-patch-strategy": "merge"
+        },
+        "ref": {
+          "description": "Ref reference to an existing Builder/ClusterBuilder",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference"
         }
       }
     },

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -169,6 +169,7 @@ func main() {
 		MaximumPlatformApiVersion: maxPlatformApi,
 		InjectedSidecarSupport:    featureFlags.InjectedSidecarSupport,
 		SSHTrustUnknownHost:       cfg.SshTrustUnknownHosts,
+		KpackClient:               client,
 	}
 
 	gitResolver := git.NewResolver(k8sClient, cfg.SshTrustUnknownHosts)

--- a/hack/local.sh
+++ b/hack/local.sh
@@ -13,8 +13,9 @@ Builds and generates a deployment yaml for kpack. This only builds linux images.
 
 Prerequisites:
 - pack or ko installed
-- kubectl installed
+- kubectl installed (recommended)
 - docker login to your registry
+- kbld and kapp (https://carvel.dev/#install)
 
 OPTIONS
   --help                          -h  prints the command usage
@@ -102,7 +103,7 @@ function main() {
 
  if "${apply}"; then
   echo "Applying $output to cluster"
-  kubectl apply -f $output
+  kapp deploy -a kpack -f $output -y
  fi
 
 }

--- a/pkg/apis/build/v1alpha1/build_validation_test.go
+++ b/pkg/apis/build/v1alpha1/build_validation_test.go
@@ -80,7 +80,7 @@ func testBuildValidation(t *testing.T, when spec.G, it spec.S) {
 
 		it("missing builder name", func() {
 			build.Spec.Builder.Image = ""
-			assertValidationError(build, apis.ErrMissingField("image").ViaField("spec", "builder"))
+			assertValidationError(build, apis.ErrMissingField("image", "ref").ViaField("spec", "builder"))
 		})
 
 		it("invalid builder name", func() {
@@ -217,7 +217,7 @@ func testBuildValidation(t *testing.T, when spec.G, it spec.S) {
 			build.Spec.Builder.Image = ""
 			assertValidationError(build,
 				apis.ErrMissingField("tags").ViaField("spec").
-					Also(apis.ErrMissingField("image").ViaField("spec", "builder")))
+					Also(apis.ErrMissingField("image", "ref").ViaField("spec", "builder")))
 		})
 
 		it("validates spec is immutable", func() {

--- a/pkg/apis/build/v1alpha2/build_pod_test.go
+++ b/pkg/apis/build/v1alpha2/build_pod_test.go
@@ -249,11 +249,12 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 
 	buildContext := buildapi.BuildContext{
 		BuildPodBuilderConfig: buildapi.BuildPodBuilderConfig{
-			StackID:      "com.builder.stack.io",
-			RunImage:     "builderregistry.io/run",
-			Uid:          2000,
-			Gid:          3000,
-			PlatformAPIs: []string{"0.7", "0.8", "0.9"},
+			StackID:       "com.builder.stack.io",
+			RunImage:      "builderregistry.io/run",
+			Uid:           2000,
+			Gid:           3000,
+			PlatformAPIs:  []string{"0.7", "0.8", "0.9"},
+			ResolvedImage: builderImage,
 		},
 		Secrets:  secrets,
 		Bindings: serviceBindings,

--- a/pkg/apis/build/v1alpha2/cluster_store_conversion_test.go
+++ b/pkg/apis/build/v1alpha2/cluster_store_conversion_test.go
@@ -24,7 +24,7 @@ func testClusterStoreConversion(t *testing.T, when spec.G, it spec.S) {
 				Annotations: map[string]string{"some-key": "some-value"},
 			},
 			Spec: ClusterStoreSpec{
-				Sources: []corev1alpha1.ImageSource{{"some-image"}, {"another-image"}},
+				Sources: []corev1alpha1.ImageSource{{Image: "some-image"}, {Image: "another-image"}},
 				ServiceAccountRef: &corev1.ObjectReference{
 					Namespace: "some-namespace",
 					Name:      "some-service-account",
@@ -65,7 +65,7 @@ func testClusterStoreConversion(t *testing.T, when spec.G, it spec.S) {
 				},
 			},
 			Spec: v1alpha1.ClusterStoreSpec{
-				Sources: []corev1alpha1.ImageSource{{"some-image"}, {"another-image"}},
+				Sources: []corev1alpha1.ImageSource{{Image: "some-image"}, {Image: "another-image"}},
 			},
 			Status: v1alpha1.ClusterStoreStatus{
 				Status: corev1alpha1.Status{},

--- a/pkg/apis/core/v1alpha1/build_types.go
+++ b/pkg/apis/core/v1alpha1/build_types.go
@@ -19,6 +19,9 @@ type BuildBuilderSpec struct {
 	// +patchStrategy=merge
 	// +listType
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,15,rep,name=imagePullSecrets"`
+
+	// Ref reference to an existing Builder/ClusterBuilder
+	Ref *corev1.ObjectReference `json:"ref,omitempty"`
 }
 
 // +k8s:openapi-gen=true

--- a/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -49,6 +49,11 @@ func (in *BuildBuilderSpec) DeepCopyInto(out *BuildBuilderSpec) {
 		*out = make([]v1.LocalObjectReference, len(*in))
 		copy(*out, *in)
 	}
+	if in.Ref != nil {
+		in, out := &in.Ref, &out.Ref
+		*out = new(v1.ObjectReference)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/dockercreds/k8sdockercreds/k8s_keychain_test.go
+++ b/pkg/dockercreds/k8sdockercreds/k8s_keychain_test.go
@@ -220,7 +220,7 @@ func testK8sSecretKeychainFactory(t *testing.T, when spec.G, it spec.S) {
 			keychain, err := keychainFactory.KeychainForSecretRef(context.TODO(), registry.SecretRef{
 				ServiceAccount:   serviceAccountName,
 				Namespace:        testNamespace,
-				ImagePullSecrets: []corev1.LocalObjectReference{{"image-pull-secret"}},
+				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "image-pull-secret"}},
 			})
 			require.NoError(t, err)
 

--- a/pkg/openapi/generated.openapi.go
+++ b/pkg/openapi/generated.openapi.go
@@ -5119,11 +5119,17 @@ func schema_pkg_apis_core_v1alpha1_BuildBuilderSpec(ref common.ReferenceCallback
 							},
 						},
 					},
+					"ref": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Ref reference to an existing Builder/ClusterBuilder",
+							Ref:         ref("k8s.io/api/core/v1.ObjectReference"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.LocalObjectReference"},
+			"k8s.io/api/core/v1.LocalObjectReference", "k8s.io/api/core/v1.ObjectReference"},
 	}
 }
 


### PR DESCRIPTION
Extends builds.kpack.io with a new optional field spec.builder.ref. This allows build resources to reference resource and cluster builders directly. Few cosmetic cleanup. Added unit test for the new field validation and implementation.

Fixes #1119 