### PR TITLE
fix: remove gcr.io reference from tutorial

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -74,8 +74,8 @@ This tutorial will walk through creating a kpack [builder](builders.md) resource
       name: default
     spec:
       sources:
-      - image: gcr.io/paketo-buildpacks/java
-      - image: gcr.io/paketo-buildpacks/nodejs
+      - image: paketobuildpacks/java
+      - image: paketobuildpacks/nodejs
     ```
    
     Apply this store to the cluster 


### PR DESCRIPTION
As a new user of kpack and buildpacks, this tripped me up.