### PR TITLE
reimplement subpath filtering experiment

### DIFF
--- a/docs/subpath_filtering.md
+++ b/docs/subpath_filtering.md
@@ -1,0 +1,41 @@
+# Support for filtering by `subPath`
+
+By default, kpack will check out the whole repository and build the project from
+the root. If you set `spec.subPath` to the name of a directory value, kpack will
+build that directory only.  When an Image is set to track a branch, and
+`subPath` is set, the Image will be rebuilt even if the new commits don't affect
+the specified path.  This can lead to unneccessary builds, especially in
+monorepos where many Images can track many paths.
+
+The "shallow clone" experimental feature can help in these situations. To enable
+the experiment, set the environment variable `GIT_RESOLVER_USE_SHALLOW_CLONE` to
+`"true"` in the kpack controller.
+
+When the feature is enabled, builds are skipped entirely when the new revision
+does not change anything in the path in question. It does so by tracking the
+"tree" of the path in question, and storing this tree value in the
+SourceResolver's status.
+
+To compute this "tree" value, kpack will perform a shallow clone of the
+reference (only metadata) in-memory, and then the equivalent of a `git ls-tree
+<ref> -- path`. This provides the git-calculated hash of the files in the path
+and its subdirectories. Any change, even to the file modes, will yield a
+different tree value.
+
+When the feature flag is enabled, this method of checking out is used regardless
+of the value of `subPath`. In other words, enabling this experiment changes how
+kpack resolves all sources, and this can exhert a higher "clone" load on your
+git servers.
+
+* If the previous build resulted in a different tree value, a new build will be
+  scheduled.
+* If the previous build resulted in the same tree value, no new build will be
+  scheduled
+
+## Annotated tags
+
+If you are tracking tags, and use annotated tags with subpath filtering and the
+`GIT_RESOLVER_USE_SHALLOW_CLONE` feature flag, then the subpath filter will
+inhibit new builds, when the subpath is unchanged. If you use this tag metadata
+in builds, or expect the tag object sha to be stamped into the image, then you
+might want to avoid this combination.

--- a/docs/subpath_filtering.md
+++ b/docs/subpath_filtering.md
@@ -40,3 +40,7 @@ If you are tracking tags, and use annotated tags with subpath filtering and the
 inhibit new builds, when the subpath is unchanged. If you use this tag metadata
 in builds, or expect the tag object sha to be stamped into the image, then you
 might want to avoid this combination.
+
+## Commit source revisions
+
+If you use a commit sha as the revision, subpath filtering does not work.

--- a/docs/subpath_filtering.md
+++ b/docs/subpath_filtering.md
@@ -22,15 +22,16 @@ reference (only metadata) in-memory, and then the equivalent of a `git ls-tree
 and its subdirectories. Any change, even to the file modes, will yield a
 different tree value.
 
-When the feature flag is enabled, this method of checking out is used regardless
-of the value of `subPath`. In other words, enabling this experiment changes how
-kpack resolves all sources, and this can exhert a higher "clone" load on your
-git servers.
-
 * If the previous build resulted in a different tree value, a new build will be
   scheduled.
 * If the previous build resulted in the same tree value, no new build will be
   scheduled
+
+## Scope of the experiment
+
+When the feature flag is enabled, this method of checking out is only used when
+the `subPath` field is set. In other words, enabling this experiment does not
+change how kpack resolves other sources.
 
 ## Annotated tags
 

--- a/pkg/git/remote_git_resolver.go
+++ b/pkg/git/remote_git_resolver.go
@@ -18,7 +18,7 @@ type remoteGitResolver struct {
 }
 
 func (r *remoteGitResolver) Resolve(auth transport.AuthMethod, sourceConfig corev1alpha1.SourceConfig) (corev1alpha1.ResolvedSourceConfig, error) {
-	if r.featureFlags.GitResolverUseShallowClone {
+	if r.featureFlags.GitResolverUseShallowClone && sourceConfig.SubPath != "" {
 		return r.ResolveByCloning(auth, sourceConfig)
 	}
 

--- a/pkg/git/remote_git_resolver_clone.go
+++ b/pkg/git/remote_git_resolver_clone.go
@@ -31,6 +31,18 @@ func (r *remoteGitResolver) ResolveByCloning(auth transport.AuthMethod, sourceCo
 		Filter:        packp.FilterBlobNone(),
 	})
 
+	if err != nil {
+		return corev1alpha1.ResolvedSourceConfig{
+			Git: &corev1alpha1.ResolvedGitSource{
+				URL:                  sourceConfig.Git.URL,
+				Revision:             sourceConfig.Git.Revision,
+				Type:                 corev1alpha1.Unknown,
+				SubPath:              sourceConfig.SubPath,
+				InitializeSubmodules: sourceConfig.Git.InitializeSubmodules,
+			},
+		}, fmt.Errorf("cloning repository: %w", err)
+	}
+
 	var resolvedRef *plumbing.Reference
 	var hash plumbing.Hash
 	var kind corev1alpha1.GitSourceKind

--- a/pkg/git/remote_git_resolver_clone.go
+++ b/pkg/git/remote_git_resolver_clone.go
@@ -44,19 +44,22 @@ func (r *remoteGitResolver) ResolveByCloning(auth transport.AuthMethod, sourceCo
 		return emptyResult, fmt.Errorf("creating remote: %w", err)
 	}
 
-	var resolvedRef *plumbing.Reference
-	var hash plumbing.Hash
-	var kind corev1alpha1.GitSourceKind
+	input := remoteGitCloneResolverInput{
+		repository: repository,
+		auth:       auth,
+		revision:   sourceConfig.Git.Revision,
+	}
+	var output *remoteGitCloneResolverOutput
 	errs := []error{}
 
 	for _, resolver := range resolvers {
-		resolvedRef, hash, kind, err = resolver(repository, auth, sourceConfig.Git.Revision)
+		output, err = resolver(input)
 		if err != nil {
 			errs = append(errs, err)
 			fmt.Printf("resolver %T failed: %v\n", resolver, err)
 			continue
 		}
-		if resolvedRef != nil {
+		if output != nil {
 			errs = nil
 			break
 		}
@@ -79,9 +82,9 @@ func (r *remoteGitResolver) ResolveByCloning(auth transport.AuthMethod, sourceCo
 	return corev1alpha1.ResolvedSourceConfig{
 		Git: &corev1alpha1.ResolvedGitSource{
 			URL:                  sourceConfig.Git.URL,
-			Revision:             hash.String(),
-			Tree:                 hashOfSubpath(sourceConfig.SubPath, hash, repository),
-			Type:                 kind,
+			Revision:             output.hash.String(),
+			Tree:                 hashOfSubpath(sourceConfig.SubPath, output.hash, repository),
+			Type:                 output.kind,
 			SubPath:              sourceConfig.SubPath,
 			InitializeSubmodules: sourceConfig.Git.InitializeSubmodules,
 		},
@@ -113,18 +116,29 @@ func hashOfSubpath(subPath string, hash plumbing.Hash, repository *gogit.Reposit
 
 }
 
-type resolverFunc func(repository *gogit.Repository, auth transport.AuthMethod, revision string) (*plumbing.Reference, plumbing.Hash, corev1alpha1.GitSourceKind, error)
+type remoteGitCloneResolverInput struct {
+	repository *gogit.Repository
+	auth       transport.AuthMethod
+	revision   string
+}
+type remoteGitCloneResolverOutput struct {
+	reference *plumbing.Reference
+	hash      plumbing.Hash
+	kind      corev1alpha1.GitSourceKind
+}
+
+type resolverFunc func(remoteGitCloneResolverInput) (*remoteGitCloneResolverOutput, error)
 
 var resolvers = []resolverFunc{resolveBranch, resolveTag, resolveRevision, looksLikeACommit}
 
-func resolveBranch(repository *gogit.Repository, auth transport.AuthMethod, branch string) (*plumbing.Reference, plumbing.Hash, corev1alpha1.GitSourceKind, error) {
+func resolveBranch(input remoteGitCloneResolverInput) (*remoteGitCloneResolverOutput, error) {
+	branch := input.revision
 	if !strings.HasPrefix(branch, "refs/heads/") {
 		branch = "refs/heads/" + branch
 	}
-	fmt.Println("fetching branch", branch)
-	err := repository.Fetch(&gogit.FetchOptions{
+	err := input.repository.Fetch(&gogit.FetchOptions{
 		RemoteName: defaultRemote,
-		Auth:       auth,
+		Auth:       input.auth,
 		RefSpecs: []gogitconfig.RefSpec{
 			gogitconfig.RefSpec(branch + ":" + branch),
 		},
@@ -132,29 +146,34 @@ func resolveBranch(repository *gogit.Repository, auth transport.AuthMethod, bran
 		Filter: packp.FilterBlobNone(),
 	})
 	if err != nil {
-		return nil, plumbing.Hash{}, corev1alpha1.Unknown, fmt.Errorf("fetching: %w", err)
+		return nil, fmt.Errorf("fetching: %w", err)
 	}
 
-	hash, err := repository.ResolveRevision(plumbing.Revision(branch))
+	hash, err := input.repository.ResolveRevision(plumbing.Revision(branch))
 	if err != nil {
-		return nil, plumbing.Hash{}, corev1alpha1.Unknown, fmt.Errorf("resolving: %w", err)
+		return nil, fmt.Errorf("resolving: %w", err)
 	}
 
-	resolvedRef, err := repository.Reference(plumbing.ReferenceName(branch), true)
+	resolvedRef, err := input.repository.Reference(plumbing.ReferenceName(branch), true)
 	if err != nil {
-		return nil, plumbing.Hash{}, corev1alpha1.Unknown, fmt.Errorf("referencing: %w", err)
+		return nil, fmt.Errorf("referencing: %w", err)
 	}
 
-	return resolvedRef, *hash, corev1alpha1.Branch, nil
+	return &remoteGitCloneResolverOutput{
+		reference: resolvedRef,
+		hash:      *hash,
+		kind:      corev1alpha1.Branch,
+	}, nil
 }
 
-func resolveTag(repository *gogit.Repository, auth transport.AuthMethod, tag string) (*plumbing.Reference, plumbing.Hash, corev1alpha1.GitSourceKind, error) {
+func resolveTag(input remoteGitCloneResolverInput) (*remoteGitCloneResolverOutput, error) {
+	tag := input.revision
 	if !strings.HasPrefix(tag, "refs/tags/") {
 		tag = "refs/tags/" + tag
 	}
-	err := repository.Fetch(&gogit.FetchOptions{
+	err := input.repository.Fetch(&gogit.FetchOptions{
 		RemoteName: defaultRemote,
-		Auth:       auth,
+		Auth:       input.auth,
 		RefSpecs: []gogitconfig.RefSpec{
 			gogitconfig.RefSpec(tag + ":" + tag),
 		},
@@ -162,38 +181,52 @@ func resolveTag(repository *gogit.Repository, auth transport.AuthMethod, tag str
 		Filter: packp.FilterBlobNone(),
 	})
 	if err != nil {
-		return nil, plumbing.Hash{}, corev1alpha1.Unknown, fmt.Errorf("fetching: %w", err)
+		return nil, fmt.Errorf("fetching: %w", err)
 	}
 
-	hash, err := repository.ResolveRevision(plumbing.Revision(tag))
+	hash, err := input.repository.ResolveRevision(plumbing.Revision(tag))
 	if err != nil {
-		return nil, plumbing.Hash{}, corev1alpha1.Unknown, fmt.Errorf("resolving: %w", err)
+		return nil, fmt.Errorf("resolving: %w", err)
 	}
 
-	resolvedTag, err := repository.Reference(plumbing.ReferenceName(tag), true)
+	resolvedTag, err := input.repository.Reference(plumbing.ReferenceName(tag), true)
 	if err != nil {
-		return nil, plumbing.Hash{}, corev1alpha1.Unknown, fmt.Errorf("referencing: %w", err)
+		return nil, fmt.Errorf("referencing: %w", err)
 	}
 
-	return resolvedTag, *hash, corev1alpha1.Tag, nil
+	return &remoteGitCloneResolverOutput{
+		reference: resolvedTag,
+		hash:      *hash,
+		kind:      corev1alpha1.Tag,
+	}, nil
 }
 
-func resolveRevision(repository *gogit.Repository, auth transport.AuthMethod, revision string) (*plumbing.Reference, plumbing.Hash, corev1alpha1.GitSourceKind, error) {
-	h := plumbing.NewHash(revision)
-	_, err := repository.Object(plumbing.AnyObject, h)
+func resolveRevision(input remoteGitCloneResolverInput) (*remoteGitCloneResolverOutput, error) {
+	commitHash := input.revision
+	h := plumbing.NewHash(commitHash)
+	_, err := input.repository.Object(plumbing.AnyObject, h)
 	if err != nil {
-		return nil, plumbing.Hash{}, corev1alpha1.Unknown, err
+		return nil, fmt.Errorf("resolving revision: %w", err)
 	}
 
-	return plumbing.NewHashReference(plumbing.ReferenceName(revision), h), h, corev1alpha1.Commit, nil
+	return &remoteGitCloneResolverOutput{
+		reference: plumbing.NewHashReference(plumbing.ReferenceName(commitHash), h),
+		hash:      h,
+		kind:      corev1alpha1.Commit,
+	}, nil
 }
 
-func looksLikeACommit(_ *gogit.Repository, auth transport.AuthMethod, revision string) (*plumbing.Reference, plumbing.Hash, corev1alpha1.GitSourceKind, error) {
+func looksLikeACommit(input remoteGitCloneResolverInput) (*remoteGitCloneResolverOutput, error) {
+	revision := input.revision
 	if !commitSHAValidator.MatchString(revision) {
-		return nil, plumbing.Hash{}, corev1alpha1.Unknown, nil
+		return nil, nil
 	}
 
 	hash := plumbing.NewHash(revision)
 
-	return plumbing.NewHashReference(plumbing.ReferenceName(revision), hash), hash, corev1alpha1.Commit, nil
+	return &remoteGitCloneResolverOutput{
+		reference: plumbing.NewHashReference(plumbing.ReferenceName(revision), hash),
+		hash:      hash,
+		kind:      corev1alpha1.Commit,
+	}, nil
 }

--- a/pkg/git/remote_git_resolver_clone.go
+++ b/pkg/git/remote_git_resolver_clone.go
@@ -52,7 +52,7 @@ func (r *remoteGitResolver) ResolveByCloning(auth transport.AuthMethod, sourceCo
 	var output *fetchResolverOutput
 	errs := []error{}
 
-	for _, resolver := range fetchResolvers {
+	for _, resolver := range relevantFetchResolversFor(sourceConfig.Git.Revision) {
 		output, err = resolver(input)
 		if err != nil {
 			errs = append(errs, err)
@@ -134,7 +134,23 @@ type fetchResolverOutput struct {
 
 type fetchResolver func(fetchResolverInput) (*fetchResolverOutput, error)
 
-var fetchResolvers = []fetchResolver{resolveBranch, resolveTag, resolveRevision, looksLikeACommit}
+var allFetchResolvers = []fetchResolver{resolveBranch, resolveTag, resolveRevision, looksLikeACommit}
+
+func relevantFetchResolversFor(revision string) []fetchResolver {
+	if strings.HasPrefix(revision, "refs/heads/") {
+		return []fetchResolver{resolveBranch}
+	}
+
+	if strings.HasPrefix(revision, "refs/tags/") {
+		return []fetchResolver{resolveTag}
+	}
+
+	if commitSHAValidator.MatchString(revision) {
+		return []fetchResolver{resolveRevision, looksLikeACommit}
+	}
+
+	return allFetchResolvers
+}
 
 func resolveBranch(input fetchResolverInput) (*fetchResolverOutput, error) {
 	branch := input.revision

--- a/pkg/git/remote_git_resolver_clone.go
+++ b/pkg/git/remote_git_resolver_clone.go
@@ -204,15 +204,27 @@ func resolveTag(input fetchResolverInput) (*fetchResolverOutput, error) {
 
 func resolveRevision(input fetchResolverInput) (*fetchResolverOutput, error) {
 	commitHash := input.revision
-	h := plumbing.NewHash(commitHash)
-	_, err := input.repository.Object(plumbing.AnyObject, h)
+	err := input.repository.Fetch(&gogit.FetchOptions{
+		RemoteName: defaultRemote,
+		Auth:       input.auth,
+		RefSpecs: []gogitconfig.RefSpec{
+			gogitconfig.RefSpec(commitHash + ":refs/heads/reference"),
+		},
+		Depth:  1,
+		Filter: packp.FilterBlobNone(),
+	})
 	if err != nil {
-		return nil, fmt.Errorf("resolving revision: %w", err)
+		return nil, fmt.Errorf("fetching: %w", err)
+	}
+
+	reference, err := input.repository.CommitObject(plumbing.NewHash(commitHash))
+	if err != nil {
+		return nil, fmt.Errorf("tag: %w", err)
 	}
 
 	return &fetchResolverOutput{
-		reference: plumbing.NewHashReference(plumbing.ReferenceName(commitHash), h),
-		hash:      h,
+		reference: plumbing.NewHashReference(plumbing.ReferenceName(commitHash), reference.Hash),
+		hash:      reference.Hash,
 		kind:      corev1alpha1.Commit,
 	}, nil
 }

--- a/pkg/git/remote_git_resolver_clone.go
+++ b/pkg/git/remote_git_resolver_clone.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	gogit "github.com/go-git/go-git/v6"
+	gogitconfig "github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
 	"github.com/go-git/go-git/v6/plumbing/transport"
@@ -20,15 +21,49 @@ const commitSHARegex = `^[a-f0-9]{40}$`
 var commitSHAValidator = regexp.MustCompile(commitSHARegex)
 
 func (r *remoteGitResolver) ResolveByCloning(auth transport.AuthMethod, sourceConfig corev1alpha1.SourceConfig) (corev1alpha1.ResolvedSourceConfig, error) {
-	// git clone
-	repository, err := gogit.Clone(memory.NewStorage(), nil, &gogit.CloneOptions{
-		URL:        sourceConfig.Git.URL,
-		Auth:       auth,
-		RemoteName: defaultRemote,
-		Bare:       true,
-		Filter:     packp.FilterBlobNone(),
-	})
+	emptyResult := corev1alpha1.ResolvedSourceConfig{
+		Git: &corev1alpha1.ResolvedGitSource{
+			URL:                  sourceConfig.Git.URL,
+			Revision:             sourceConfig.Git.Revision,
+			Type:                 corev1alpha1.Unknown,
+			SubPath:              sourceConfig.SubPath,
+			InitializeSubmodules: sourceConfig.Git.InitializeSubmodules,
+		},
+	}
+	// git init --bare
+	repository, err := gogit.Init(memory.NewStorage())
+	if err != nil {
+		return emptyResult, fmt.Errorf("initializing repository: %w", err)
+	}
 
+	_, err = repository.CreateRemote(&gogitconfig.RemoteConfig{
+		Name: defaultRemote,
+		URLs: []string{sourceConfig.Git.URL},
+	})
+	if err != nil {
+		return emptyResult, fmt.Errorf("creating remote: %w", err)
+	}
+
+	var resolvedRef *plumbing.Reference
+	var hash plumbing.Hash
+	var kind corev1alpha1.GitSourceKind
+	errs := []error{}
+
+	for _, resolver := range resolvers {
+		resolvedRef, hash, kind, err = resolver(repository, auth, sourceConfig.Git.Revision)
+		if err != nil {
+			errs = append(errs, err)
+			fmt.Printf("resolver %T failed: %v\n", resolver, err)
+			continue
+		}
+		if resolvedRef != nil {
+			errs = nil
+			break
+		}
+	}
+	err = errors.Join(errs...)
+
+	// errs could contain errors from some resolvers, only one of them needs to be successful.
 	if err != nil {
 		return corev1alpha1.ResolvedSourceConfig{
 			Git: &corev1alpha1.ResolvedGitSource{
@@ -38,35 +73,7 @@ func (r *remoteGitResolver) ResolveByCloning(auth transport.AuthMethod, sourceCo
 				SubPath:              sourceConfig.SubPath,
 				InitializeSubmodules: sourceConfig.Git.InitializeSubmodules,
 			},
-		}, fmt.Errorf("cloning repository: %w", err)
-	}
-
-	var resolvedRef *plumbing.Reference
-	var hash plumbing.Hash
-	var kind corev1alpha1.GitSourceKind
-	errs := []error{}
-
-	for _, resolver := range resolvers {
-		resolvedRef, hash, kind, err = resolver(repository, sourceConfig.Git.Revision)
-		if err != nil {
-			errs = append(errs, err)
-		}
-		if resolvedRef != nil {
-			break
-		}
-	}
-
-	// errs could contain errors from some resolvers, only one of them needs to be successful.
-	if resolvedRef == nil {
-		return corev1alpha1.ResolvedSourceConfig{
-			Git: &corev1alpha1.ResolvedGitSource{
-				URL:                  sourceConfig.Git.URL,
-				Revision:             sourceConfig.Git.Revision,
-				Type:                 corev1alpha1.Unknown,
-				SubPath:              sourceConfig.SubPath,
-				InitializeSubmodules: sourceConfig.Git.InitializeSubmodules,
-			},
-		}, fmt.Errorf("revision \"%s\": unable to fetch references for repository: %w", sourceConfig.Git.Revision, errors.Join(errs...))
+		}, fmt.Errorf("revision \"%s\": unable to fetch references for repository: %w", sourceConfig.Git.Revision, err)
 	}
 
 	return corev1alpha1.ResolvedSourceConfig{
@@ -106,35 +113,72 @@ func hashOfSubpath(subPath string, hash plumbing.Hash, repository *gogit.Reposit
 
 }
 
-type resolverFunc func(repository *gogit.Repository, revision string) (*plumbing.Reference, plumbing.Hash, corev1alpha1.GitSourceKind, error)
+type resolverFunc func(repository *gogit.Repository, auth transport.AuthMethod, revision string) (*plumbing.Reference, plumbing.Hash, corev1alpha1.GitSourceKind, error)
 
 var resolvers = []resolverFunc{resolveBranch, resolveTag, resolveRevision, looksLikeACommit}
 
-func resolveBranch(repository *gogit.Repository, branch string) (*plumbing.Reference, plumbing.Hash, corev1alpha1.GitSourceKind, error) {
-	resolvedBranch, err := repository.Branch(branch)
+func resolveBranch(repository *gogit.Repository, auth transport.AuthMethod, branch string) (*plumbing.Reference, plumbing.Hash, corev1alpha1.GitSourceKind, error) {
+	if !strings.HasPrefix(branch, "refs/heads/") {
+		branch = "refs/heads/" + branch
+	}
+	fmt.Println("fetching branch", branch)
+	err := repository.Fetch(&gogit.FetchOptions{
+		RemoteName: defaultRemote,
+		Auth:       auth,
+		RefSpecs: []gogitconfig.RefSpec{
+			gogitconfig.RefSpec(branch + ":" + branch),
+		},
+		Depth:  1,
+		Filter: packp.FilterBlobNone(),
+	})
 	if err != nil {
-		return nil, plumbing.Hash{}, corev1alpha1.Unknown, err
+		return nil, plumbing.Hash{}, corev1alpha1.Unknown, fmt.Errorf("fetching: %w", err)
 	}
 
-	resolvedRef := plumbing.NewSymbolicReference(plumbing.ReferenceName(branch), plumbing.ReferenceName(resolvedBranch.Merge))
-	h, err := repository.ResolveRevision(plumbing.Revision(resolvedBranch.Merge))
+	hash, err := repository.ResolveRevision(plumbing.Revision(branch))
 	if err != nil {
-		return nil, plumbing.Hash{}, corev1alpha1.Unknown, err
+		return nil, plumbing.Hash{}, corev1alpha1.Unknown, fmt.Errorf("resolving: %w", err)
 	}
 
-	return resolvedRef, *h, corev1alpha1.Branch, nil
+	resolvedRef, err := repository.Reference(plumbing.ReferenceName(branch), true)
+	if err != nil {
+		return nil, plumbing.Hash{}, corev1alpha1.Unknown, fmt.Errorf("referencing: %w", err)
+	}
+
+	return resolvedRef, *hash, corev1alpha1.Branch, nil
 }
 
-func resolveTag(repository *gogit.Repository, tag string) (*plumbing.Reference, plumbing.Hash, corev1alpha1.GitSourceKind, error) {
-	resolvedTag, err := repository.Tag(tag)
+func resolveTag(repository *gogit.Repository, auth transport.AuthMethod, tag string) (*plumbing.Reference, plumbing.Hash, corev1alpha1.GitSourceKind, error) {
+	if !strings.HasPrefix(tag, "refs/tags/") {
+		tag = "refs/tags/" + tag
+	}
+	err := repository.Fetch(&gogit.FetchOptions{
+		RemoteName: defaultRemote,
+		Auth:       auth,
+		RefSpecs: []gogitconfig.RefSpec{
+			gogitconfig.RefSpec(tag + ":" + tag),
+		},
+		Depth:  1,
+		Filter: packp.FilterBlobNone(),
+	})
 	if err != nil {
-		return nil, plumbing.Hash{}, corev1alpha1.Unknown, err
+		return nil, plumbing.Hash{}, corev1alpha1.Unknown, fmt.Errorf("fetching: %w", err)
 	}
 
-	return resolvedTag, resolvedTag.Hash(), corev1alpha1.Tag, nil
+	hash, err := repository.ResolveRevision(plumbing.Revision(tag))
+	if err != nil {
+		return nil, plumbing.Hash{}, corev1alpha1.Unknown, fmt.Errorf("resolving: %w", err)
+	}
+
+	resolvedTag, err := repository.Reference(plumbing.ReferenceName(tag), true)
+	if err != nil {
+		return nil, plumbing.Hash{}, corev1alpha1.Unknown, fmt.Errorf("referencing: %w", err)
+	}
+
+	return resolvedTag, *hash, corev1alpha1.Tag, nil
 }
 
-func resolveRevision(repository *gogit.Repository, revision string) (*plumbing.Reference, plumbing.Hash, corev1alpha1.GitSourceKind, error) {
+func resolveRevision(repository *gogit.Repository, auth transport.AuthMethod, revision string) (*plumbing.Reference, plumbing.Hash, corev1alpha1.GitSourceKind, error) {
 	h := plumbing.NewHash(revision)
 	_, err := repository.Object(plumbing.AnyObject, h)
 	if err != nil {
@@ -144,7 +188,7 @@ func resolveRevision(repository *gogit.Repository, revision string) (*plumbing.R
 	return plumbing.NewHashReference(plumbing.ReferenceName(revision), h), h, corev1alpha1.Commit, nil
 }
 
-func looksLikeACommit(_ *gogit.Repository, revision string) (*plumbing.Reference, plumbing.Hash, corev1alpha1.GitSourceKind, error) {
+func looksLikeACommit(_ *gogit.Repository, auth transport.AuthMethod, revision string) (*plumbing.Reference, plumbing.Hash, corev1alpha1.GitSourceKind, error) {
 	if !commitSHAValidator.MatchString(revision) {
 		return nil, plumbing.Hash{}, corev1alpha1.Unknown, nil
 	}

--- a/pkg/git/remote_git_resolver_clone.go
+++ b/pkg/git/remote_git_resolver_clone.go
@@ -180,11 +180,8 @@ func resolveBranch(input fetchResolverInput) (*fetchResolverOutput, error) {
 }
 
 func resolveTag(input fetchResolverInput) (*fetchResolverOutput, error) {
-	tag := input.revision
-	ref := tag
-	if !strings.HasPrefix(ref, "refs/tags/") {
-		ref = "refs/tags/" + ref
-	}
+	tag := strings.TrimPrefix(input.revision, "refs/tags/")
+	ref := "refs/tags/" + tag
 	err := input.repository.Fetch(&gogit.FetchOptions{
 		RemoteName: defaultRemote,
 		Auth:       input.auth,

--- a/pkg/git/remote_git_resolver_clone.go
+++ b/pkg/git/remote_git_resolver_clone.go
@@ -22,13 +22,11 @@ var commitSHAValidator = regexp.MustCompile(commitSHARegex)
 func (r *remoteGitResolver) ResolveByCloning(auth transport.AuthMethod, sourceConfig corev1alpha1.SourceConfig) (corev1alpha1.ResolvedSourceConfig, error) {
 	// git clone
 	repository, err := gogit.Clone(memory.NewStorage(), nil, &gogit.CloneOptions{
-		URL:           sourceConfig.Git.URL,
-		Auth:          auth,
-		RemoteName:    defaultRemote,
-		ReferenceName: plumbing.ReferenceName(sourceConfig.Git.Revision),
-		Depth:         1,
-		Bare:          true,
-		Filter:        packp.FilterBlobNone(),
+		URL:        sourceConfig.Git.URL,
+		Auth:       auth,
+		RemoteName: defaultRemote,
+		Bare:       true,
+		Filter:     packp.FilterBlobNone(),
 	})
 
 	if err != nil {
@@ -58,6 +56,7 @@ func (r *remoteGitResolver) ResolveByCloning(auth transport.AuthMethod, sourceCo
 		}
 	}
 
+	// errs could contain errors from some resolvers, only one of them needs to be successful.
 	if resolvedRef == nil {
 		return corev1alpha1.ResolvedSourceConfig{
 			Git: &corev1alpha1.ResolvedGitSource{

--- a/pkg/git/remote_git_resolver_clone.go
+++ b/pkg/git/remote_git_resolver_clone.go
@@ -66,15 +66,7 @@ func (r *remoteGitResolver) ResolveByCloning(auth transport.AuthMethod, sourceCo
 
 	err = errors.Join(errs...)
 	if err != nil {
-		return corev1alpha1.ResolvedSourceConfig{
-			Git: &corev1alpha1.ResolvedGitSource{
-				URL:                  sourceConfig.Git.URL,
-				Revision:             sourceConfig.Git.Revision,
-				Type:                 corev1alpha1.Unknown,
-				SubPath:              sourceConfig.SubPath,
-				InitializeSubmodules: sourceConfig.Git.InitializeSubmodules,
-			},
-		}, fmt.Errorf("revision \"%s\": unable to fetch references for repository: %w", sourceConfig.Git.Revision, err)
+		return emptyResult, fmt.Errorf("revision \"%s\": unable to fetch references for repository: %w", sourceConfig.Git.Revision, err)
 	}
 
 	return corev1alpha1.ResolvedSourceConfig{

--- a/pkg/git/remote_git_resolver_clone.go
+++ b/pkg/git/remote_git_resolver_clone.go
@@ -44,19 +44,18 @@ func (r *remoteGitResolver) ResolveByCloning(auth transport.AuthMethod, sourceCo
 		return emptyResult, fmt.Errorf("creating remote: %w", err)
 	}
 
-	input := remoteGitCloneResolverInput{
+	input := fetchResolverInput{
 		repository: repository,
 		auth:       auth,
 		revision:   sourceConfig.Git.Revision,
 	}
-	var output *remoteGitCloneResolverOutput
+	var output *fetchResolverOutput
 	errs := []error{}
 
-	for _, resolver := range resolvers {
+	for _, resolver := range fetchResolvers {
 		output, err = resolver(input)
 		if err != nil {
 			errs = append(errs, err)
-			fmt.Printf("resolver %T failed: %v\n", resolver, err)
 			continue
 		}
 		if output != nil {
@@ -64,9 +63,8 @@ func (r *remoteGitResolver) ResolveByCloning(auth transport.AuthMethod, sourceCo
 			break
 		}
 	}
-	err = errors.Join(errs...)
 
-	// errs could contain errors from some resolvers, only one of them needs to be successful.
+	err = errors.Join(errs...)
 	if err != nil {
 		return corev1alpha1.ResolvedSourceConfig{
 			Git: &corev1alpha1.ResolvedGitSource{
@@ -97,6 +95,13 @@ func hashOfSubpath(subPath string, hash plumbing.Hash, repository *gogit.Reposit
 		return ""
 	}
 
+	// If the object is an annotated tag, first resolve to the commit it points
+	// to.
+	tag, err := repository.TagObject(hash)
+	if err == nil {
+		hash = tag.Target
+	}
+
 	commit, err := repository.CommitObject(hash)
 	if err != nil {
 		return ""
@@ -116,22 +121,22 @@ func hashOfSubpath(subPath string, hash plumbing.Hash, repository *gogit.Reposit
 
 }
 
-type remoteGitCloneResolverInput struct {
+type fetchResolverInput struct {
 	repository *gogit.Repository
 	auth       transport.AuthMethod
 	revision   string
 }
-type remoteGitCloneResolverOutput struct {
+type fetchResolverOutput struct {
 	reference *plumbing.Reference
 	hash      plumbing.Hash
 	kind      corev1alpha1.GitSourceKind
 }
 
-type resolverFunc func(remoteGitCloneResolverInput) (*remoteGitCloneResolverOutput, error)
+type fetchResolver func(fetchResolverInput) (*fetchResolverOutput, error)
 
-var resolvers = []resolverFunc{resolveBranch, resolveTag, resolveRevision, looksLikeACommit}
+var fetchResolvers = []fetchResolver{resolveBranch, resolveTag, resolveRevision, looksLikeACommit}
 
-func resolveBranch(input remoteGitCloneResolverInput) (*remoteGitCloneResolverOutput, error) {
+func resolveBranch(input fetchResolverInput) (*fetchResolverOutput, error) {
 	branch := input.revision
 	if !strings.HasPrefix(branch, "refs/heads/") {
 		branch = "refs/heads/" + branch
@@ -159,23 +164,24 @@ func resolveBranch(input remoteGitCloneResolverInput) (*remoteGitCloneResolverOu
 		return nil, fmt.Errorf("referencing: %w", err)
 	}
 
-	return &remoteGitCloneResolverOutput{
+	return &fetchResolverOutput{
 		reference: resolvedRef,
 		hash:      *hash,
 		kind:      corev1alpha1.Branch,
 	}, nil
 }
 
-func resolveTag(input remoteGitCloneResolverInput) (*remoteGitCloneResolverOutput, error) {
+func resolveTag(input fetchResolverInput) (*fetchResolverOutput, error) {
 	tag := input.revision
-	if !strings.HasPrefix(tag, "refs/tags/") {
-		tag = "refs/tags/" + tag
+	ref := tag
+	if !strings.HasPrefix(ref, "refs/tags/") {
+		ref = "refs/tags/" + ref
 	}
 	err := input.repository.Fetch(&gogit.FetchOptions{
 		RemoteName: defaultRemote,
 		Auth:       input.auth,
 		RefSpecs: []gogitconfig.RefSpec{
-			gogitconfig.RefSpec(tag + ":" + tag),
+			gogitconfig.RefSpec(ref + ":" + ref),
 		},
 		Depth:  1,
 		Filter: packp.FilterBlobNone(),
@@ -184,24 +190,19 @@ func resolveTag(input remoteGitCloneResolverInput) (*remoteGitCloneResolverOutpu
 		return nil, fmt.Errorf("fetching: %w", err)
 	}
 
-	hash, err := input.repository.ResolveRevision(plumbing.Revision(tag))
+	reference, err := input.repository.Tag(tag)
 	if err != nil {
-		return nil, fmt.Errorf("resolving: %w", err)
+		return nil, fmt.Errorf("tag: %w", err)
 	}
 
-	resolvedTag, err := input.repository.Reference(plumbing.ReferenceName(tag), true)
-	if err != nil {
-		return nil, fmt.Errorf("referencing: %w", err)
-	}
-
-	return &remoteGitCloneResolverOutput{
-		reference: resolvedTag,
-		hash:      *hash,
+	return &fetchResolverOutput{
+		reference: reference,
+		hash:      reference.Hash(),
 		kind:      corev1alpha1.Tag,
 	}, nil
 }
 
-func resolveRevision(input remoteGitCloneResolverInput) (*remoteGitCloneResolverOutput, error) {
+func resolveRevision(input fetchResolverInput) (*fetchResolverOutput, error) {
 	commitHash := input.revision
 	h := plumbing.NewHash(commitHash)
 	_, err := input.repository.Object(plumbing.AnyObject, h)
@@ -209,14 +210,14 @@ func resolveRevision(input remoteGitCloneResolverInput) (*remoteGitCloneResolver
 		return nil, fmt.Errorf("resolving revision: %w", err)
 	}
 
-	return &remoteGitCloneResolverOutput{
+	return &fetchResolverOutput{
 		reference: plumbing.NewHashReference(plumbing.ReferenceName(commitHash), h),
 		hash:      h,
 		kind:      corev1alpha1.Commit,
 	}, nil
 }
 
-func looksLikeACommit(input remoteGitCloneResolverInput) (*remoteGitCloneResolverOutput, error) {
+func looksLikeACommit(input fetchResolverInput) (*fetchResolverOutput, error) {
 	revision := input.revision
 	if !commitSHAValidator.MatchString(revision) {
 		return nil, nil
@@ -224,7 +225,7 @@ func looksLikeACommit(input remoteGitCloneResolverInput) (*remoteGitCloneResolve
 
 	hash := plumbing.NewHash(revision)
 
-	return &remoteGitCloneResolverOutput{
+	return &fetchResolverOutput{
 		reference: plumbing.NewHashReference(plumbing.ReferenceName(revision), hash),
 		hash:      hash,
 		kind:      corev1alpha1.Commit,

--- a/pkg/git/remote_git_resolver_clone.go
+++ b/pkg/git/remote_git_resolver_clone.go
@@ -219,7 +219,7 @@ func resolveRevision(input fetchResolverInput) (*fetchResolverOutput, error) {
 
 	reference, err := input.repository.CommitObject(plumbing.NewHash(commitHash))
 	if err != nil {
-		return nil, fmt.Errorf("tag: %w", err)
+		return nil, fmt.Errorf("lookup: %w", err)
 	}
 
 	return &fetchResolverOutput{

--- a/pkg/git/remote_git_resolver_test.go
+++ b/pkg/git/remote_git_resolver_test.go
@@ -29,6 +29,7 @@ func testRemoteGitResolver(t *testing.T, when spec.G, it spec.S) {
 		tag                     = "commit-tag"
 		tagCommit               = "ad7897c0fb8e7d9a9ba41fa66072cf06095a6cfc"
 		goSubPathTree           = "a39771a7651f97faf5c72e08224d857fc35133db"
+		tagSubPathTree          = "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
 	)
 
 	when("#Resolve", func() {
@@ -100,15 +101,20 @@ func testRemoteGitResolver(t *testing.T, when spec.G, it spec.S) {
 					SubPath: "/tree",
 				})
 				require.NoError(t, err)
-
-				assert.Equal(t, corev1alpha1.ResolvedSourceConfig{
+				expected := corev1alpha1.ResolvedSourceConfig{
 					Git: &corev1alpha1.ResolvedGitSource{
 						URL:      tagsUrl,
 						Revision: tagCommit,
 						Type:     corev1alpha1.Tag,
 						SubPath:  "/tree",
 					},
-				}, resolvedGitSource)
+				}
+
+				if featureFlags.GitResolverUseShallowClone {
+					expected.Git.Tree = tagSubPathTree
+				}
+
+				assert.Equal(t, expected, resolvedGitSource)
 			})
 		})
 


### PR DESCRIPTION
The error was incorrectly being ignored, and resulted in wrong error messages about branches not found.

The subpath filtering experiment now
* Is only turned on if `subPath` is set
* creates an in-memory bare repository
* tries to fetch the remote reference as a branch, a tag, and a commit individually, every time without fetching any blobs.

Includes a document describing it in some detail.