### PR TITLE
Reject SecretKeyRef in Build/Image env validation

### DIFF
--- a/pkg/apis/build/v1alpha2/build_validation.go
+++ b/pkg/apis/build/v1alpha2/build_validation.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 
 	authv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmp"
 
@@ -35,6 +36,7 @@ func (bs *BuildSpec) Validate(ctx context.Context) *apis.FieldError {
 		Also(bs.validateImmutableFields(ctx)).
 		Also(validateCnbBindings(ctx, bs.CNBBindings).ViaField("cnbBindings")).
 		Also(bs.validateNodeSelector(ctx)).
+		Also(validateBuildEnvSecretKeyRefs(bs.Env).ViaField("env")).
 		Also(validateNotary(ctx, bs.Notary).ViaField("notary"))
 }
 
@@ -78,6 +80,16 @@ func (bs *BuildSpec) validateNodeSelector(_ context.Context) *apis.FieldError {
 	}
 	return nil
 
+}
+
+func validateBuildEnvSecretKeyRefs(env []corev1.EnvVar) *apis.FieldError {
+	var errs *apis.FieldError
+	for i, envVar := range env {
+		if envVar.ValueFrom != nil && envVar.ValueFrom.SecretKeyRef != nil {
+			errs = errs.Also(apis.ErrGeneric("secretKeyRef is not supported for build environment variables", fmt.Sprintf("[%d].valueFrom.secretKeyRef", i)))
+		}
+	}
+	return errs
 }
 
 func (lb *LastBuild) Validate(context context.Context) *apis.FieldError {

--- a/pkg/apis/build/v1alpha2/build_validation_test.go
+++ b/pkg/apis/build/v1alpha2/build_validation_test.go
@@ -128,6 +128,22 @@ func testBuildValidation(t *testing.T, when spec.G, it spec.S) {
 			assert.Nil(t, buildUsingRef.Validate(context.TODO()))
 		})
 
+		it("disallows secretKeyRef in build env", func() {
+			build.Spec.Env = []corev1.EnvVar{
+				{
+					Name: "SECRET_TOKEN",
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "victim-secret"},
+							Key:                  "token",
+						},
+					},
+				},
+			}
+
+			assertValidationError(build, context.TODO(), apis.ErrGeneric("secretKeyRef is not supported for build environment variables", "spec.env[0].valueFrom.secretKeyRef"))
+		})
+
 		it("multiple sources", func() {
 			build.Spec.Source.Git = &corev1alpha1.Git{
 				URL:      "http://github.com/repo",

--- a/pkg/apis/build/v1alpha2/image_validation.go
+++ b/pkg/apis/build/v1alpha2/image_validation.go
@@ -176,7 +176,8 @@ func (ib *ImageBuild) Validate(ctx context.Context) *apis.FieldError {
 	}
 
 	return ib.Services.Validate(ctx).ViaField("services").
-		Also(validateCnbBindings(ctx, ib.CNBBindings).ViaField("cnbBindings"))
+		Also(validateCnbBindings(ctx, ib.CNBBindings).ViaField("cnbBindings")).
+		Also(validateBuildEnvSecretKeyRefs(ib.Env).ViaField("env"))
 }
 
 func validateBuilder(builder v1.ObjectReference) *apis.FieldError {

--- a/pkg/apis/build/v1alpha2/image_validation_test.go
+++ b/pkg/apis/build/v1alpha2/image_validation_test.go
@@ -466,6 +466,22 @@ func testImageValidation(t *testing.T, when spec.G, it spec.S) {
 
 		})
 
+		it("disallows secretKeyRef in build env", func() {
+			image.Spec.Build.Env = []corev1.EnvVar{
+				{
+					Name: "SECRET_TOKEN",
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "victim-secret"},
+							Key:                  "token",
+						},
+					},
+				},
+			}
+
+			assertValidationError(image, ctx, apis.ErrGeneric("secretKeyRef is not supported for build environment variables", "spec.build.env[0].valueFrom.secretKeyRef"))
+		})
+
 		when("validating cnb bindings if they have been created by the kpack controller", func() {
 			ctx := apis.WithUserInfo(ctx, &authv1.UserInfo{Username: kpackControllerServiceAccountUsername})
 			it("validates cnb bindings have a name", func() {


### PR DESCRIPTION
The Build and Image webhooks accepted env[].valueFrom.secretKeyRef, which the controller then copied into the build Pod's prepare init container as PLATFORM_ENV_*. build-init writes those into /platform/env, exposing the resolved Secret value to buildpacks. A tenant who can create kpack Build/Image resources but lacks `get secrets` or `create pods` could use this confused-deputy path to read arbitrary same-namespace Secrets via build logs, network egress, or the built image.

Reject env[].valueFrom.secretKeyRef in BuildSpec and ImageBuild validation for both spec.env and spec.build.env. Literal env[].value is unaffected, matching the documented schema (name/value pairs).