### PR TITLE
Allow providing custom CA to images created by controller

### DIFF
--- a/pkg/apis/build/v1alpha2/build_pod.go
+++ b/pkg/apis/build/v1alpha2/build_pod.go
@@ -299,6 +299,7 @@ func (b *Build) BuildPod(images BuildPodImages, buildContext BuildContext) (*cor
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Env: []corev1.EnvVar{
 			platformApiVersionEnvVar,
+			serviceBindingRootEnv,
 		},
 		SecurityContext: containerSecurityContext(),
 	}
@@ -337,6 +338,7 @@ func (b *Build) BuildPod(images BuildPodImages, buildContext BuildContext) (*cor
 							homeEnv,
 							{Name: CacheTagEnvVar, Value: b.Spec.RegistryCacheTag()},
 							{Name: TerminationMessagePathEnvVar, Value: completionTerminationMessagePath},
+							serviceBindingRootEnv,
 						},
 						Args: args(
 							b.notaryArgs(),
@@ -355,6 +357,7 @@ func (b *Build) BuildPod(images BuildPodImages, buildContext BuildContext) (*cor
 								reportMount,
 								notaryV1Mount,
 							},
+							bindingVolumeMounts,
 						),
 						ImagePullPolicy: corev1.PullIfNotPresent,
 						SecurityContext: containerSecurityContext(),
@@ -412,6 +415,7 @@ func (b *Build) BuildPod(images BuildPodImages, buildContext BuildContext) (*cor
 								Name:  "INSECURE_SSH_TRUST_UNKNOWN_HOSTS",
 								Value: strconv.FormatBool(buildContext.SSHTrustUnknownHost),
 							},
+							serviceBindingRootEnv,
 						),
 						ImagePullPolicy: corev1.PullIfNotPresent,
 						WorkingDir:      "/workspace",
@@ -425,6 +429,7 @@ func (b *Build) BuildPod(images BuildPodImages, buildContext BuildContext) (*cor
 								homeMount,
 								projectMetadataMount,
 							},
+							bindingVolumeMounts,
 						),
 					},
 				)
@@ -508,7 +513,8 @@ func (b *Build) BuildPod(images BuildPodImages, buildContext BuildContext) (*cor
 							workspaceVolume,
 							homeMount,
 							reportMount,
-						}, cacheVolumes),
+						},
+							cacheVolumes),
 						Env: envs(
 							[]corev1.EnvVar{
 								homeEnv,


### PR DESCRIPTION
As the images are being built with pack, it's possible to use ca-certificates buildpack features to allow providing a custom CA (referenced in #207). This commit adds the environment variable and mounts for the service bindings needed by the ca-certificates runtime (the helper is added to image /layers/paketo-buildbacks_ca-certificates/helper/helper)