### PR TITLE
build: publish genuine multi-arch (amd64+arm64) images via ko-direct build

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -87,10 +87,28 @@ function generate_kbld_config_pack() {
 EOT
 }
 
+function generate_ko_config() {
+  ko_config_path=$1
+
+  prefix="github.com/pivotal/kpack/pkg/apis/build/v1alpha2"
+  cat <<EOT > $ko_config_path
+  defaultBaseImage: paketobuildpacks/run-jammy-tiny
+
+  builds:
+  - id: controller
+    ldflags:
+    - -X ${prefix}.CompletionCommand=/ko-app/completion
+    - -X ${prefix}.PrepareCommand=/ko-app/build-init
+    - -X ${prefix}.RebaseCommand=/ko-app/rebase
+EOT
+}
+
 function generate_kbld_config_ko() {
   kbld_config_path=$1
   ko_config_path=$2
   registry=$3
+
+  generate_ko_config $ko_config_path
 
   args=("--disable-optimizations")
   args+=($buildArgs)
@@ -147,19 +165,62 @@ function generate_kbld_config_ko() {
   - image: completion
     newImage: $completion_image
 EOT
+}
 
-  prefix="github.com/pivotal/kpack/pkg/apis/build/v1alpha2"
-  cat <<EOT > $ko_config_path
-  defaultBaseImage: paketobuildpacks/run-jammy-tiny
+# generate_kbld_config_ko_multiarch builds each binary into a genuine multi-arch
+# image index by invoking ko directly, then records the resulting index digests
+# as kbld overrides.
+#
+# kbld's ko integration builds for the host platform only (it collapses ko's
+# multi-platform build down to a single, host-arch manifest), so the published
+# images don't run on other architectures (e.g. arm64 clusters fail with
+# "exec format error"). Calling `ko build --platform=...` ourselves produces a
+# real OCI image index covering every requested platform; feeding those refs to
+# kbld as overrides keeps the rest of the release pipeline (manifest rewriting,
+# digest pinning) unchanged.
+function generate_kbld_config_ko_multiarch() {
+  kbld_config_path=$1
+  ko_config_path=$2
+  registry=$3
+  platforms=$4
 
-  builds:
-  - id: controller
-    ldflags:
-    - -X ${prefix}.CompletionCommand=/ko-app/completion
-    - -X ${prefix}.PrepareCommand=/ko-app/build-init
-    - -X ${prefix}.RebaseCommand=/ko-app/rebase
+  generate_ko_config $ko_config_path
+
+  # Each entry is "kbld-image-name:cmd-dir:destination-image-ref".
+  images=(
+    "controller:cmd/controller:$controller_image"
+    "webhook:cmd/webhook:$webhook_image"
+    "build-init:cmd/build-init:$build_init_image"
+    "build-waiter:cmd/build-waiter:$build_waiter_image"
+    "rebase:cmd/rebase:$rebase_image"
+    "completion:cmd/completion:$completion_image"
+  )
+
+  cat <<EOT > $kbld_config_path
+  apiVersion: kbld.k14s.io/v1alpha1
+  kind: Config
+  overrides:
+  - image: lifecycle
+    newImage: mirror.gcr.io/buildpacksio/lifecycle
 EOT
 
+  for entry in "${images[@]}"; do
+    name=${entry%%:*}
+    rest=${entry#*:}
+    dir=${rest%%:*}
+    dest=${rest#*:}
+
+    echo "Building multi-arch image ($platforms) for $name via ko" >&2
+    # ko pushes the built index to KO_DOCKER_REPO (with --bare, the repo is
+    # used verbatim) and prints the resulting digest-pinned index ref.
+    ref=$(KO_DOCKER_REPO="$dest" KO_CONFIG_PATH="$ko_config_path" \
+      ko build --bare --platform="$platforms" --disable-optimizations "./$dir")
+
+    cat <<EOT >> $kbld_config_path
+  - image: $name
+    newImage: $ref
+EOT
+  done
 }
 
 function compile() {
@@ -181,8 +242,15 @@ function compile() {
   temp_dir=$(mktemp -d)
   kbld_config_path="${temp_dir}/kbld-config"
   ko_config_path="${temp_dir}/.ko.yaml"
+  # PLATFORMS optionally requests a multi-arch (e.g. "linux/amd64,linux/arm64")
+  # build. When unset, the native, single-arch behavior is preserved.
+  PLATFORMS=${PLATFORMS:-}
   if [ $type = "ko" ]; then
-    generate_kbld_config_ko $kbld_config_path $ko_config_path $registry
+    if [ -n "$PLATFORMS" ]; then
+      generate_kbld_config_ko_multiarch $kbld_config_path $ko_config_path $registry $PLATFORMS
+    else
+      generate_kbld_config_ko $kbld_config_path $ko_config_path $registry
+    fi
   elif [ $type = "pack" ]; then
     generate_kbld_config_pack $kbld_config_path $registry
   else


### PR DESCRIPTION
## Problem

The released kpack images (`controller`, `webhook`, `build-init`, `build-waiter`, `rebase`, `completion`) are **linux/amd64 only**. On arm64 clusters the kubelet pulls the only (amd64) variant and every kpack pod crashes with:

```
exec /cnb/process/controller: exec format error
```

I hit this on an all-arm64 cluster (OCI Ampere / Raspberry Pi): both `kpack-controller` and `kpack-webhook` CrashLoopBackOff.

## Root cause

`hack/build.sh` does not build the images with `ko` directly — it generates a kbld config whose `sources` point at `ko`, and lets **kbld** drive the ko build. kbld's ko integration builds for the **host platform only**: it collapses ko's multi-platform build down to a single, host-arch manifest.

I verified this against the actually-published manifest (inspected via the registry token + manifest API):

- kbld-driven ko build (current behavior, even with `defaultPlatforms` in `.ko.yaml` **or** `--platform=all` threaded through kbld's ko `rawOptions`) ⇒ a single-arch image:
  `application/vnd.docker.distribution.manifest.v2+json`
- `ko build --platform=linux/amd64,linux/arm64` invoked **directly** (bypassing kbld) ⇒ a real OCI image index (`application/vnd.oci.image.index.v1+json`) containing both `linux/amd64` and `linux/arm64`.

So setting `defaultPlatforms` (my original attempt in this PR) is **not** sufficient — kbld discards the extra platforms. The build has to call `ko` itself.

## Fix

When the `PLATFORMS` env var is set (e.g. `PLATFORMS=linux/amd64,linux/arm64`), build each of the six binaries by calling `ko build --bare --platform="$PLATFORMS"` directly, capture each resulting **digest-pinned multi-arch index ref**, and feed those refs to kbld as `overrides` instead of having kbld build them. The rest of the release pipeline (ytt rendering, kbld manifest rewriting and digest pinning) is unchanged.

- `PLATFORMS` **unset** preserves the existing native single-arch kbld+ko path **byte-for-byte** — no behavior change for current users / CI.
- The controller's ldflags (`CompletionCommand`, `PrepareCommand`, `RebaseCommand`) are preserved: the same generated `.ko.yaml` is passed to the direct `ko` build via `KO_CONFIG_PATH` (the `.ko.yaml` generation was extracted into a small shared `generate_ko_config` helper).
- The default base image (`paketobuildpacks/run-jammy-tiny`) is already multi-arch, so no base-image change is needed.

To publish multi-arch images:

```
PLATFORMS=linux/amd64,linux/arm64 ./hack/local.sh --build-type ko --registry <registry>
```

## Notes

- DCO signed-off.
- Happy to wire `PLATFORMS=linux/amd64,linux/arm64` into the release workflow and/or add arm64 to the `pack` build path if maintainers want it in a follow-up.
